### PR TITLE
Add support for schema definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ install-phars:
 platform:
 	docker-compose down
 	docker-compose up -d
-	sleep 20
+	bin/wait-for-all.sh
 
 clean:
 	rm -rf build
@@ -78,6 +78,6 @@ clean:
 benchmark:
 	docker-compose down
 	docker-compose up -d
-	sleep 15
+	bin/wait-for-all.sh
 	PHP_VERSION=$(PHP_VERSION) $(PHP) ./vendor/bin/phpbench run benchmarks/AvroEncodingBench.php --report=aggregate --retry-threshold=5
 	docker-compose down

--- a/README.md
+++ b/README.md
@@ -358,6 +358,28 @@ Assert::assertEquals($deserializedUser, $user);
 
 ```
 
+## Schema builder
+
+This library also provides means of defining schemas using php, very similar to 
+the [SchemaBuilder API provided by the Java SDK](https://avro.apache.org/docs/1.7.6/api/java/org/apache/avro/SchemaBuilder.html):
+
+```php
+<?php
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use FlixTech\AvroSerializer\Objects\Schema\Record\FieldOption;
+
+Schema::record()
+    ->name('object')
+    ->namespace('org.acme')
+    ->doc('A test object')
+    ->aliases(['stdClass', 'array'])
+    ->field('name', Schema::string(), FieldOption::doc('Name of the object'), FieldOption::orderDesc())
+    ->field('answer', Schema::int(), FieldOption::default(42), FieldOption::orderAsc(), FieldOption::aliases('wrong', 'correct'))
+    ->field('ignore', Schema::boolean(), FieldOption::orderIgnore())
+    ->parse();
+```
+
 ## Examples
 
 This library provides a few executable examples in the [examples](examples) folder. You should have a look to get an

--- a/bin/wait-for-all.sh
+++ b/bin/wait-for-all.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+bin/wait-for-it.sh localhost:2181 -t 30 -- echo "zookeeper is up"
+bin/wait-for-it.sh localhost:9092 -t 30 -- echo "kafka broker is up"
+bin/wait-for-it.sh localhost:8081 -t 30 -- echo "schema registry is up"

--- a/bin/wait-for-it.sh
+++ b/bin/wait-for-it.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+else
+    WAITFORIT_ISBUSY=0
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi

--- a/examples/SchemaBuilder.php
+++ b/examples/SchemaBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Examples;
+
+use Dotenv\Dotenv;
+use FlixTech\AvroSerializer\Objects\DefaultRecordSerializerFactory;
+use FlixTech\AvroSerializer\Objects\Schema;
+use PHPUnit\Framework\Assert;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$dotEnv = new Dotenv(__DIR__ . '/..');
+$dotEnv->load();
+$dotEnv->required('SCHEMA_REGISTRY_HOST')->notEmpty();
+
+$recordSerializer = DefaultRecordSerializerFactory::get(getenv('SCHEMA_REGISTRY_HOST'));
+
+$avroSchema = '{
+  "type": "record",
+  "name": "user",
+  "fields": [
+    {"name": "firstName", "type": "string"},
+    {"name": "lastName", "type": "string"},
+    {"name": "age", "type": "int"}
+  ]
+}';
+
+echo "Avro Schema:\n";
+echo $avroSchema . "\n\n";
+
+$userRecord = [
+    'firstName' => 'John',
+    'lastName' => 'Doe',
+    'age' => 42,
+];
+
+echo "User record to be serialized:\n";
+echo \var_export($userRecord, true) . "\n\n";
+
+$parsedSchema = \AvroSchema::parse($avroSchema);
+$serialized = $recordSerializer->encodeRecord('users-value', $parsedSchema, $userRecord);
+
+echo "Confluent Avro wire format serialized binary as hex:\n";
+echo bin2hex($serialized) . "\n\n";
+
+// The reader schema may be different than the writer's one, according to the compatibility policies
+$readerSchema = Schema::record()
+    ->name('user')
+    ->field('firstName', Schema::string())
+    ->field('age', Schema::int())
+    ->parse();
+
+$deserializedRecord = $recordSerializer->decodeMessage($serialized, $readerSchema);
+
+echo "Deserialized User:\n";
+echo \var_export($deserializedRecord, true) . "\n";
+
+Assert::assertEquals($deserializedRecord, [
+    'firstName' => 'John',
+    'age' => 42,
+]);

--- a/src/Objects/Definition.php
+++ b/src/Objects/Definition.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects;
+
+interface Definition
+{
+    /**
+     * @return mixed
+     */
+    public function serialize();
+}

--- a/src/Objects/Schema.php
+++ b/src/Objects/Schema.php
@@ -146,7 +146,7 @@ abstract class Schema implements Definition
         return new DurationType();
     }
 
-    public function parse(): AvroSchema
+    final public function parse(): AvroSchema
     {
         $avro = $this->serialize();
 

--- a/src/Objects/Schema.php
+++ b/src/Objects/Schema.php
@@ -8,17 +8,26 @@ use AvroSchema;
 use FlixTech\AvroSerializer\Objects\Schema\ArrayType;
 use FlixTech\AvroSerializer\Objects\Schema\BooleanType;
 use FlixTech\AvroSerializer\Objects\Schema\BytesType;
+use FlixTech\AvroSerializer\Objects\Schema\DateType;
 use FlixTech\AvroSerializer\Objects\Schema\DoubleType;
+use FlixTech\AvroSerializer\Objects\Schema\DurationType;
 use FlixTech\AvroSerializer\Objects\Schema\EnumType;
 use FlixTech\AvroSerializer\Objects\Schema\FixedType;
 use FlixTech\AvroSerializer\Objects\Schema\FloatType;
 use FlixTech\AvroSerializer\Objects\Schema\IntType;
+use FlixTech\AvroSerializer\Objects\Schema\LocalTimestampMicros;
+use FlixTech\AvroSerializer\Objects\Schema\LocalTimestampMillisType;
 use FlixTech\AvroSerializer\Objects\Schema\LongType;
 use FlixTech\AvroSerializer\Objects\Schema\MapType;
 use FlixTech\AvroSerializer\Objects\Schema\NullType;
 use FlixTech\AvroSerializer\Objects\Schema\RecordType;
 use FlixTech\AvroSerializer\Objects\Schema\StringType;
+use FlixTech\AvroSerializer\Objects\Schema\TimeMicrosType;
+use FlixTech\AvroSerializer\Objects\Schema\TimeMillisType;
+use FlixTech\AvroSerializer\Objects\Schema\TimestampMicrosType;
+use FlixTech\AvroSerializer\Objects\Schema\TimestampMillisType;
 use FlixTech\AvroSerializer\Objects\Schema\UnionType;
+use FlixTech\AvroSerializer\Objects\Schema\UuidType;
 
 abstract class Schema implements Definition
 {
@@ -90,6 +99,51 @@ abstract class Schema implements Definition
     public static function fixed(): FixedType
     {
         return new FixedType();
+    }
+
+    public static function uuid(): UuidType
+    {
+        return new UuidType();
+    }
+
+    public static function date(): DateType
+    {
+        return new DateType();
+    }
+
+    public static function timeMillis(): TimeMillisType
+    {
+        return new TimeMillisType();
+    }
+
+    public static function timeMicros(): TimeMicrosType
+    {
+        return new TimeMicrosType();
+    }
+
+    public static function timestampMillis(): TimestampMillisType
+    {
+        return new TimestampMillisType();
+    }
+
+    public static function timestampMicros(): TimestampMicrosType
+    {
+        return new TimestampMicrosType();
+    }
+
+    public static function localTimestampMillis(): LocalTimestampMillisType
+    {
+        return new LocalTimestampMillisType();
+    }
+
+    public static function localTimestampMicros(): LocalTimestampMicros
+    {
+        return new LocalTimestampMicros();
+    }
+
+    public static function duration(): DurationType
+    {
+        return new DurationType();
     }
 
     public function parse(): AvroSchema

--- a/src/Objects/Schema.php
+++ b/src/Objects/Schema.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects;
+
+use AvroSchema;
+use FlixTech\AvroSerializer\Objects\Schema\ArrayType;
+use FlixTech\AvroSerializer\Objects\Schema\BooleanType;
+use FlixTech\AvroSerializer\Objects\Schema\BytesType;
+use FlixTech\AvroSerializer\Objects\Schema\DoubleType;
+use FlixTech\AvroSerializer\Objects\Schema\EnumType;
+use FlixTech\AvroSerializer\Objects\Schema\FixedType;
+use FlixTech\AvroSerializer\Objects\Schema\FloatType;
+use FlixTech\AvroSerializer\Objects\Schema\IntType;
+use FlixTech\AvroSerializer\Objects\Schema\LongType;
+use FlixTech\AvroSerializer\Objects\Schema\MapType;
+use FlixTech\AvroSerializer\Objects\Schema\NullType;
+use FlixTech\AvroSerializer\Objects\Schema\RecordType;
+use FlixTech\AvroSerializer\Objects\Schema\StringType;
+use FlixTech\AvroSerializer\Objects\Schema\UnionType;
+
+abstract class Schema implements Definition
+{
+    public static function null(): NullType
+    {
+        return new NullType();
+    }
+
+    public static function boolean(): BooleanType
+    {
+        return new BooleanType();
+    }
+
+    public static function int(): IntType
+    {
+        return new IntType();
+    }
+
+    public static function long(): LongType
+    {
+        return new LongType();
+    }
+
+    public static function float(): FloatType
+    {
+        return new FloatType();
+    }
+
+    public static function double(): DoubleType
+    {
+        return new DoubleType();
+    }
+
+    public static function bytes(): BytesType
+    {
+        return new BytesType();
+    }
+
+    public static function string(): StringType
+    {
+        return new StringType();
+    }
+
+    public static function record(): RecordType
+    {
+        return new RecordType();
+    }
+
+    public static function enum(): EnumType
+    {
+        return new EnumType();
+    }
+
+    public static function array(): ArrayType
+    {
+        return new ArrayType();
+    }
+
+    public static function map(): MapType
+    {
+        return new MapType();
+    }
+
+    public static function union(Schema $type, Schema ...$types): UnionType
+    {
+        return new UnionType($type, ...$types);
+    }
+
+    public static function fixed(): FixedType
+    {
+        return new FixedType();
+    }
+
+    public function parse(): AvroSchema
+    {
+        $avro = $this->serialize();
+
+        return AvroSchema::real_parse($avro);
+    }
+}

--- a/src/Objects/Schema/ArrayType.php
+++ b/src/Objects/Schema/ArrayType.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class ArrayType extends ComplexType
+{
+    public function __construct()
+    {
+        parent::__construct('array');
+    }
+
+    public function items(Schema $schema): self
+    {
+        return $this->attribute('items', $schema);
+    }
+
+    /**
+     * @param array<mixed> $default
+     */
+    public function default(array $default): self
+    {
+        return $this->attribute('default', $default);
+    }
+}

--- a/src/Objects/Schema/BooleanType.php
+++ b/src/Objects/Schema/BooleanType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class BooleanType extends PrimitiveType
+{
+    public function __construct()
+    {
+        parent::__construct('boolean');
+    }
+}

--- a/src/Objects/Schema/BytesType.php
+++ b/src/Objects/Schema/BytesType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class BytesType extends PrimitiveType
+{
+    public function __construct()
+    {
+        parent::__construct('bytes');
+    }
+}

--- a/src/Objects/Schema/ComplexType.php
+++ b/src/Objects/Schema/ComplexType.php
@@ -12,29 +12,20 @@ abstract class ComplexType extends Schema
     /**
      * @var array<string, mixed>
      */
-    private $attributes = [];
+    private $attributes;
 
     /**
      * @var string
      */
     private $type;
 
-    public function __construct(string $type)
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function __construct(string $type, array $attributes = [])
     {
         $this->type = $type;
-    }
-
-    /**
-     * @param mixed $value
-     *
-     * @return static
-     */
-    public function attribute(string $name, $value): self
-    {
-        $schema = clone $this;
-        $schema->attributes[$name] = $value;
-
-        return $schema;
+        $this->attributes = $attributes;
     }
 
     /**
@@ -57,5 +48,18 @@ abstract class ComplexType extends Schema
         }
 
         return $record;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return static
+     */
+    protected function attribute(string $name, $value): self
+    {
+        $schema = clone $this;
+        $schema->attributes[$name] = $value;
+
+        return $schema;
     }
 }

--- a/src/Objects/Schema/ComplexType.php
+++ b/src/Objects/Schema/ComplexType.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Definition;
+use FlixTech\AvroSerializer\Objects\Schema;
+
+abstract class ComplexType extends Schema
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private $attributes = [];
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    public function __construct(string $type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return static
+     */
+    public function attribute(string $name, $value): self
+    {
+        $schema = clone $this;
+        $schema->attributes[$name] = $value;
+
+        return $schema;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function serialize(): array
+    {
+        $record = [
+            'type' => $this->type,
+        ];
+
+        foreach ($this->attributes as $attributeName => $attributeValue) {
+            if ($attributeValue instanceof Definition) {
+                $record[$attributeName] = $attributeValue->serialize();
+
+                continue;
+            }
+
+            $record[$attributeName] = $attributeValue;
+        }
+
+        return $record;
+    }
+}

--- a/src/Objects/Schema/DateType.php
+++ b/src/Objects/Schema/DateType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class DateType extends LogicalType
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'date',
+            Schema::int()->serialize()
+        );
+    }
+}

--- a/src/Objects/Schema/DoubleType.php
+++ b/src/Objects/Schema/DoubleType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class DoubleType extends PrimitiveType
+{
+    public function __construct()
+    {
+        parent::__construct('double');
+    }
+}

--- a/src/Objects/Schema/DurationType.php
+++ b/src/Objects/Schema/DurationType.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class DurationType extends LogicalType
+{
+    public function __construct()
+    {
+        parent::__construct('duration', 'fixed', [
+            'size' => 12,
+        ]);
+    }
+
+    public function name(string $name): self
+    {
+        return $this->attribute('name', $name);
+    }
+
+    public function namespace(string $namespace): self
+    {
+        return $this->attribute('namespace', $namespace);
+    }
+
+    public function aliases(string $alias, string ...$aliases): self
+    {
+        \array_unshift($aliases, $alias);
+
+        return $this->attribute('aliases', $aliases);
+    }
+}

--- a/src/Objects/Schema/EnumType.php
+++ b/src/Objects/Schema/EnumType.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class EnumType extends ComplexType
+{
+    public function __construct()
+    {
+        parent::__construct('enum');
+    }
+
+    public function name(string $name): self
+    {
+        return $this->attribute('name', $name);
+    }
+
+    public function namespace(string $namespace): self
+    {
+        return $this->attribute('namespace', $namespace);
+    }
+
+    public function aliases(string $alias, string ...$aliases): self
+    {
+        \array_unshift($aliases, $alias);
+
+        return $this->attribute('aliases', $aliases);
+    }
+
+    public function doc(string $doc): self
+    {
+        return $this->attribute('doc', $doc);
+    }
+
+    public function symbols(string $symbol, string ...$symbols): self
+    {
+        \array_unshift($symbols, $symbol);
+
+        return $this->attribute('symbols', $symbols);
+    }
+
+    public function default(string $default): self
+    {
+        return $this->attribute('default', $default);
+    }
+}

--- a/src/Objects/Schema/FixedType.php
+++ b/src/Objects/Schema/FixedType.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class FixedType extends ComplexType
+{
+    public function __construct()
+    {
+        parent::__construct('fixed');
+    }
+
+    public function namespace(string $namespace): self
+    {
+        return $this->attribute('namespace', $namespace);
+    }
+
+    public function name(string $name): self
+    {
+        return $this->attribute('name', $name);
+    }
+
+    public function size(int $size): self
+    {
+        return $this->attribute('size', $size);
+    }
+
+    public function aliases(string $alias, string ...$aliases): self
+    {
+        \array_unshift($aliases, $alias);
+
+        return $this->attribute('aliases', $aliases);
+    }
+}

--- a/src/Objects/Schema/FloatType.php
+++ b/src/Objects/Schema/FloatType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class FloatType extends PrimitiveType
+{
+    public function __construct()
+    {
+        parent::__construct('float');
+    }
+}

--- a/src/Objects/Schema/IntType.php
+++ b/src/Objects/Schema/IntType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class IntType extends PrimitiveType
+{
+    public function __construct()
+    {
+        parent::__construct('int');
+    }
+}

--- a/src/Objects/Schema/LocalTimestampMicros.php
+++ b/src/Objects/Schema/LocalTimestampMicros.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class LocalTimestampMicros extends LogicalType
+{
+    public function __construct()
+    {
+        parent::__construct('local-timestamp-micros', Schema::long()->serialize());
+    }
+}

--- a/src/Objects/Schema/LocalTimestampMillisType.php
+++ b/src/Objects/Schema/LocalTimestampMillisType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class LocalTimestampMillisType extends LogicalType
+{
+    public function __construct()
+    {
+        parent::__construct('local-timestamp-millis', Schema::long()->serialize());
+    }
+}

--- a/src/Objects/Schema/LogicalType.php
+++ b/src/Objects/Schema/LogicalType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+abstract class LogicalType extends ComplexType
+{
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function __construct(string $logicalType, string $annotatedType, array $attributes = [])
+    {
+        $attributes['logicalType'] = $logicalType;
+
+        parent::__construct($annotatedType, $attributes);
+    }
+}

--- a/src/Objects/Schema/LongType.php
+++ b/src/Objects/Schema/LongType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class LongType extends PrimitiveType
+{
+    public function __construct()
+    {
+        parent::__construct('long');
+    }
+}

--- a/src/Objects/Schema/MapType.php
+++ b/src/Objects/Schema/MapType.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class MapType extends ComplexType
+{
+    public function __construct()
+    {
+        parent::__construct('map');
+    }
+
+    public function values(Schema $schema): self
+    {
+        return $this->attribute('values', $schema);
+    }
+
+    /**
+     * @param array<string, mixed> $default
+     */
+    public function default(array $default): self
+    {
+        return $this->attribute('default', $default);
+    }
+}

--- a/src/Objects/Schema/NullType.php
+++ b/src/Objects/Schema/NullType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class NullType extends PrimitiveType
+{
+    public function __construct()
+    {
+        parent::__construct('null');
+    }
+}

--- a/src/Objects/Schema/PrimitiveType.php
+++ b/src/Objects/Schema/PrimitiveType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+abstract class PrimitiveType extends Schema
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    public function __construct(string $type)
+    {
+        $this->type = $type;
+    }
+
+    final public function serialize(): string
+    {
+        return $this->type;
+    }
+}

--- a/src/Objects/Schema/Record/Field.php
+++ b/src/Objects/Schema/Record/Field.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Record;
+
+use FlixTech\AvroSerializer\Objects\Definition;
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class Field implements Definition
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var Schema
+     */
+    private $type;
+
+    /**
+     * @var array<FieldOption>
+     */
+    private $options;
+
+    public function __construct(
+        string $name,
+        Schema $type,
+        FieldOption ...$options
+    ) {
+        $this->name = $name;
+        $this->type = $type;
+        $this->options = $options;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function serialize(): array
+    {
+        $field = [
+            'name' => $this->name,
+            'type' => $this->type->serialize(),
+        ];
+
+        foreach ($this->options as $option) {
+            $field[$option->getName()] = $option->getValue();
+        }
+
+        return $field;
+    }
+}

--- a/src/Objects/Schema/Record/FieldAliases.php
+++ b/src/Objects/Schema/Record/FieldAliases.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Record;
+
+class FieldAliases extends FieldOption
+{
+    public function __construct(string $alias, string ...$aliases)
+    {
+        \array_unshift($aliases, $alias);
+        parent::__construct('aliases', $aliases);
+    }
+}

--- a/src/Objects/Schema/Record/FieldDefault.php
+++ b/src/Objects/Schema/Record/FieldDefault.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Record;
+
+class FieldDefault extends FieldOption
+{
+    /**
+     * @param mixed $default
+     */
+    public function __construct($default)
+    {
+        parent::__construct('default', $default);
+    }
+}

--- a/src/Objects/Schema/Record/FieldDoc.php
+++ b/src/Objects/Schema/Record/FieldDoc.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Record;
+
+class FieldDoc extends FieldOption
+{
+    public function __construct(string $doc)
+    {
+        parent::__construct('doc', $doc);
+    }
+}

--- a/src/Objects/Schema/Record/FieldOption.php
+++ b/src/Objects/Schema/Record/FieldOption.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Record;
+
+abstract class FieldOption
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @param mixed $value
+     */
+    public function __construct(string $name, $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    public static function doc(string $doc): FieldDoc
+    {
+        return new FieldDoc($doc);
+    }
+
+    /**
+     * @param mixed $default
+     */
+    public static function default($default): FieldDefault
+    {
+        return new FieldDefault($default);
+    }
+
+    public static function orderAsc(): FieldOrder
+    {
+        return FieldOrder::asc();
+    }
+
+    public static function orderDesc(): FieldOrder
+    {
+        return FieldOrder::desc();
+    }
+
+    public static function orderIgnore(): FieldOrder
+    {
+        return FieldOrder::ignore();
+    }
+
+    public static function aliases(string $alias, string ...$other): FieldAliases
+    {
+        return new FieldAliases($alias, ...$other);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Objects/Schema/Record/FieldOrder.php
+++ b/src/Objects/Schema/Record/FieldOrder.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Record;
+
+class FieldOrder extends FieldOption
+{
+    private function __construct(string $order)
+    {
+        parent::__construct('order', $order);
+    }
+
+    public static function asc(): self
+    {
+        return new self('ascending');
+    }
+
+    public static function desc(): self
+    {
+        return new self('descending');
+    }
+
+    public static function ignore(): self
+    {
+        return new self('ignore');
+    }
+}

--- a/src/Objects/Schema/RecordType.php
+++ b/src/Objects/Schema/RecordType.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use FlixTech\AvroSerializer\Objects\Schema\Record\Field;
+use FlixTech\AvroSerializer\Objects\Schema\Record\FieldOption;
+
+class RecordType extends ComplexType
+{
+    /**
+     * @var array<Field>
+     */
+    private $fields = [];
+
+    public function __construct()
+    {
+        parent::__construct('record');
+    }
+
+    public function name(string $name): self
+    {
+        return $this->attribute('name', $name);
+    }
+
+    public function namespace(string $namespace): self
+    {
+        return $this->attribute('namespace', $namespace);
+    }
+
+    public function doc(string $doc): self
+    {
+        return $this->attribute('doc', $doc);
+    }
+
+    /**
+     * @param array<string> $aliases
+     */
+    public function aliases(array $aliases): self
+    {
+        return $this->attribute('aliases', $aliases);
+    }
+
+    public function field(string $name, Schema $type, FieldOption ...$options): self
+    {
+        $record = clone $this;
+        $record->fields[] = new Field($name, $type, ...$options);
+
+        return $record;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function serialize(): array
+    {
+        $record = parent::serialize();
+
+        $record['fields'] = \array_map(function (Field $field) {
+            return $field->serialize();
+        }, $this->fields);
+
+        return $record;
+    }
+}

--- a/src/Objects/Schema/StringType.php
+++ b/src/Objects/Schema/StringType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class StringType extends PrimitiveType
+{
+    public function __construct()
+    {
+        parent::__construct('string');
+    }
+}

--- a/src/Objects/Schema/TimeMicrosType.php
+++ b/src/Objects/Schema/TimeMicrosType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class TimeMicrosType extends LogicalType
+{
+    public function __construct()
+    {
+        parent::__construct('time-micros', Schema::long()->serialize());
+    }
+}

--- a/src/Objects/Schema/TimeMillisType.php
+++ b/src/Objects/Schema/TimeMillisType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class TimeMillisType extends LogicalType
+{
+    public function __construct()
+    {
+        parent::__construct('time-millis', Schema::int()->serialize());
+    }
+}

--- a/src/Objects/Schema/TimestampMicrosType.php
+++ b/src/Objects/Schema/TimestampMicrosType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class TimestampMicrosType extends LogicalType
+{
+    public function __construct()
+    {
+        parent::__construct('timestamp-micros', Schema::long()->serialize());
+    }
+}

--- a/src/Objects/Schema/TimestampMillisType.php
+++ b/src/Objects/Schema/TimestampMillisType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class TimestampMillisType extends LogicalType
+{
+    public function __construct()
+    {
+        parent::__construct('timestamp-millis', Schema::long()->serialize());
+    }
+}

--- a/src/Objects/Schema/UnionType.php
+++ b/src/Objects/Schema/UnionType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class UnionType extends Schema
+{
+    /**
+     * @var array<Schema>
+     */
+    private $types;
+
+    public function __construct(Schema $type, Schema ...$types)
+    {
+        \array_unshift($types, $type);
+        $this->types = $types;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function serialize(): array
+    {
+        return \array_map(function (Schema $schema) {
+            return $schema->serialize();
+        }, $this->types);
+    }
+}

--- a/src/Objects/Schema/UuidType.php
+++ b/src/Objects/Schema/UuidType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class UuidType extends LogicalType
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'uuid',
+            Schema::string()->serialize()
+        );
+    }
+}

--- a/test/Objects/Schema/ArrayTypeTest.php
+++ b/test/Objects/Schema/ArrayTypeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use PHPUnit\Framework\TestCase;
+
+class ArrayTypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_serialize_array_types(): void
+    {
+        $serializedArray = Schema::array()
+            ->items(Schema::string())
+            ->default(['foo', 'bar'])
+            ->serialize();
+
+        $expectedArray = [
+            'type' => 'array',
+            'items' => 'string',
+            'default' => ['foo', 'bar'],
+        ];
+
+        $this->assertEquals($expectedArray, $serializedArray);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_parse_array_types(): void
+    {
+        $parsedSchema = Schema::array()
+            ->items(Schema::string())
+            ->default(['foo', 'bar'])
+            ->parse();
+
+        $this->assertInstanceOf(\AvroSchema::class, $parsedSchema);
+        $this->assertEquals('array', $parsedSchema->type());
+    }
+}

--- a/test/Objects/Schema/EnumTypeTest.php
+++ b/test/Objects/Schema/EnumTypeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use PHPUnit\Framework\TestCase;
+
+class EnumTypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_serialize_enum_types(): void
+    {
+        $serializedEnum = Schema::enum()
+            ->name('Suit')
+            ->namespace('com.org.acme')
+            ->aliases('outfit', 'elegant')
+            ->doc('Suit up!')
+            ->symbols(...['SPADES', 'HEARTS', 'DIAMONDS', 'CLUBS'])
+            ->default('SPADES')
+            ->serialize();
+
+        $expectedEnum = [
+            'type' => 'enum',
+            'name' => 'Suit',
+            'namespace' => 'com.org.acme',
+            'aliases' => ['outfit', 'elegant'],
+            'doc' => 'Suit up!',
+            'symbols' => ['SPADES', 'HEARTS', 'DIAMONDS', 'CLUBS'],
+            'default' => 'SPADES',
+        ];
+
+        $this->assertEquals($expectedEnum, $serializedEnum);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_parse_enum_types(): void
+    {
+        $parsedSchema = Schema::enum()
+            ->name('Suit')
+            ->namespace('com.org.acme')
+            ->aliases('outfit', 'elegant')
+            ->doc('Suit up!')
+            ->symbols(...['SPADES', 'HEARTS', 'DIAMONDS', 'CLUBS'])
+            ->default('SPADES')
+            ->parse();
+
+        $this->assertInstanceOf(\AvroSchema::class, $parsedSchema);
+    }
+}

--- a/test/Objects/Schema/FixedTypeTest.php
+++ b/test/Objects/Schema/FixedTypeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use PHPUnit\Framework\TestCase;
+
+class FixedTypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_serialize_fixed_types(): void
+    {
+        $serializedFixedType = Schema::fixed()
+            ->namespace('org.acme')
+            ->name('md5')
+            ->size(16)
+            ->aliases('hash', 'fileHash')
+            ->serialize();
+
+        $expectedFixedType = [
+            'type' => 'fixed',
+            'namespace' => 'org.acme',
+            'name' => 'md5',
+            'size' => 16,
+            'aliases' => ['hash', 'fileHash'],
+        ];
+
+        $this->assertEquals($expectedFixedType, $serializedFixedType);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_parse_fixed_types(): void
+    {
+        $parsedSchema = Schema::fixed()
+            ->namespace('org.acme')
+            ->name('md5')
+            ->size(16)
+            ->aliases('hash', 'fileHash')
+            ->parse();
+
+        $this->assertInstanceOf(\AvroSchema::class, $parsedSchema);
+        $this->assertEquals('fixed', $parsedSchema->type());
+    }
+}

--- a/test/Objects/Schema/LogicalTypeTest.php
+++ b/test/Objects/Schema/LogicalTypeTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use PHPUnit\Framework\TestCase;
+
+class LogicalTypeTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideLogicalTypes()
+     */
+    public function it_should_serialize_simple_logical_types(Schema $type, string $expectedAnnotatedType, string $expectedLogicalType)
+    {
+        $expectedSchema = [
+            'type' => $expectedAnnotatedType,
+            'logicalType' => $expectedLogicalType,
+        ];
+
+        $this->assertEquals($expectedSchema, $type->serialize());
+    }
+
+    /**
+     * @test
+     * @dataProvider provideLogicalTypes()
+     */
+    public function it_should_parse_simple_logical_types(Schema $type, string $expectedType, string $expectedLogicalType)
+    {
+        $parsedSchema = $type->parse();
+        $this->assertEquals($expectedType, $parsedSchema->type());
+        $this->assertEquals($expectedLogicalType, $parsedSchema->logical_type());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_serialize_duration_types()
+    {
+        $schema = Schema::duration()
+            ->name('User')
+            ->namespace('org.acme')
+            ->aliases('foobar')
+            ->serialize();
+
+        $expected = [
+            'logicalType' => 'duration',
+            'type' => 'fixed',
+            'name' => 'User',
+            'namespace' => 'org.acme',
+            'aliases' => ['foobar'],
+            'size' => 12,
+        ];
+
+        $this->assertEquals($expected, $schema);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_parse_duration_types()
+    {
+        $parsedSchema = Schema::duration()
+            ->name('User')
+            ->namespace('org.acme')
+            ->aliases('foobar')
+            ->parse();
+
+        $this->assertEquals('fixed', $parsedSchema->type());
+        $this->assertEquals('duration', $parsedSchema->logical_type());
+    }
+
+    public function provideLogicalTypes(): array
+    {
+        return [
+            'uuid' => [Schema::uuid(), 'string', 'uuid'],
+            'date' => [Schema::date(), 'int', 'date'],
+            'time-millis' => [Schema::timeMillis(), 'int', 'time-millis'],
+            'time-micros' => [Schema::timeMicros(), 'long', 'time-micros'],
+            'timestamp-millis' => [Schema::timestampMillis(), 'long', 'timestamp-millis'],
+            'timestamp-micros' => [Schema::timestampMicros(), 'long', 'timestamp-micros'],
+            'local-timestamp-millis' => [Schema::localTimestampMillis(), 'long', 'local-timestamp-millis'],
+            'local-timestamp-micros' => [Schema::localTimestampMicros(), 'long', 'local-timestamp-micros'],
+        ];
+    }
+}

--- a/test/Objects/Schema/MapTypeTest.php
+++ b/test/Objects/Schema/MapTypeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use PHPUnit\Framework\TestCase;
+
+class MapTypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_serialize_map_types(): void
+    {
+        $serializedMap = Schema::map()
+            ->values(Schema::long())
+            ->default(['answer' => 42])
+            ->serialize();
+
+        $expectedMap = [
+            'type' => 'map',
+            'values' => 'long',
+            'default' => [
+                'answer' => 42,
+            ],
+        ];
+
+        $this->assertEquals($expectedMap, $serializedMap);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_parse_map_types(): void
+    {
+        $parsedSchema = Schema::map()
+            ->values(Schema::long())
+            ->default(['answer' => 42])
+            ->parse();
+
+        $this->assertInstanceOf(\AvroSchema::class, $parsedSchema);
+        $this->assertEquals('map', $parsedSchema->type());
+    }
+}

--- a/test/Objects/Schema/PrimitiveTypeTest.php
+++ b/test/Objects/Schema/PrimitiveTypeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use PHPUnit\Framework\TestCase;
+
+class PrimitiveTypeTest extends TestCase
+{
+    /**
+     * @dataProvider providePrimitiveTypes()
+     * @test
+     */
+    public function it_should_serialize_primitive_types(Schema $type, string $expectedName)
+    {
+        $this->assertEquals($expectedName, $type->serialize());
+    }
+
+    /**
+     * @dataProvider providePrimitiveTypes()
+     * @test
+     */
+    public function it_should_parse_primitive_types(Schema $type, string $expectedName)
+    {
+        $parsedSchema = $type->parse();
+        $this->assertInstanceOf(\AvroSchema::class, $parsedSchema);
+        $this->assertEquals($expectedName, $parsedSchema->type());
+    }
+
+    public function providePrimitiveTypes(): array
+    {
+        return [
+            'null' => [Schema::null(), 'null'],
+            'boolean' => [Schema::boolean(), 'boolean'],
+            'int' => [Schema::int(), 'int'],
+            'long' => [Schema::long(), 'long'],
+            'float' => [Schema::float(), 'float'],
+            'double' => [Schema::double(), 'double'],
+            'bytes' => [Schema::bytes(), 'bytes'],
+            'string' => [Schema::string(), 'string'],
+        ];
+    }
+}

--- a/test/Objects/Schema/RecordTypeTest.php
+++ b/test/Objects/Schema/RecordTypeTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use FlixTech\AvroSerializer\Objects\Schema\Record\FieldOption;
+use PHPUnit\Framework\TestCase;
+
+class RecordTypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_serialize_record_types(): void
+    {
+        $serializedRecord = Schema::record()
+            ->name('object')
+            ->namespace('org.acme')
+            ->doc('A test object')
+            ->aliases(['stdClass', 'array'])
+            ->field('name', Schema::string(), FieldOption::doc('Name of the object'), FieldOption::orderDesc())
+            ->field('answer', Schema::int(), FieldOption::default(42), FieldOption::orderAsc(), FieldOption::aliases('wrong', 'correct'))
+            ->field('ignore', Schema::boolean(), FieldOption::orderIgnore())
+            ->serialize();
+
+        $expectedRecord = [
+            'type' => 'record',
+            'name' => 'object',
+            'namespace' => 'org.acme',
+            'doc' => 'A test object',
+            'aliases' => ['stdClass', 'array'],
+            'fields' => [
+                [
+                    'name' => 'name',
+                    'type' => 'string',
+                    'doc' => 'Name of the object',
+                    'order' => 'descending',
+                ],
+                [
+                    'name' => 'answer',
+                    'type' => 'int',
+                    'default' => 42,
+                    'order' => 'ascending',
+                    'aliases' => ['wrong', 'correct'],
+                ],
+                [
+                    'name' => 'ignore',
+                    'type' => 'boolean',
+                    'order' => 'ignore',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedRecord, $serializedRecord);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_parse_record_types(): void
+    {
+        $parsedSchema = Schema::record()
+            ->name('object')
+            ->namespace('org.acme')
+            ->doc('A test object')
+            ->aliases(['stdClass', 'array'])
+            ->field('name', Schema::string(), FieldOption::doc('Name of the object'), FieldOption::orderDesc())
+            ->field('answer', Schema::int(), FieldOption::default(42), FieldOption::orderAsc(), FieldOption::aliases('wrong', 'correct'))
+            ->field('ignore', Schema::boolean(), FieldOption::orderIgnore())
+            ->parse();
+
+        $this->assertInstanceOf(\AvroSchema::class, $parsedSchema);
+        $this->assertEquals('record', $parsedSchema->type());
+    }
+}

--- a/test/Objects/Schema/UnionTypeTest.php
+++ b/test/Objects/Schema/UnionTypeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use PHPUnit\Framework\TestCase;
+
+class UnionTypeTest extends TestCase
+{
+    public function testShouldSerializeUnionTypes(): void
+    {
+        $serializedUnion = Schema::union(
+            Schema::null(),
+            Schema::string(),
+            Schema::long()
+        )->serialize();
+
+        $expectedUnion = ['null', 'string', 'long'];
+
+        $this->assertEquals($expectedUnion, $serializedUnion);
+    }
+}


### PR DESCRIPTION
This PR adds support for defining avro schemas by using pure PHP. The API is somehow similar to the Schema Builder API provided by the [Java SDK](https://avro.apache.org/docs/1.7.6/api/java/org/apache/avro/SchemaBuilder.html).

The idea is to ease the process of defining schemas. Also, I plan to use this as a base for implementing the generation of avro schemas from classes and custom annotations, also kind similar to what we can see [here](https://github.com/sksamuel/avro4s#schemas).

An example of the suggested syntax:

```php
<?php

use FlixTech\AvroSerializer\Objects\Schema;
use FlixTech\AvroSerializer\Objects\Schema\Record\FieldOption;

Schema::record()
    ->name('object')
    ->namespace('org.acme')
    ->doc('A test object')
    ->aliases(['stdClass', 'array'])
    ->field('name', Schema::string(), FieldOption::doc('Name of the object'), FieldOption::orderDesc())
    ->field('answer', Schema::int(), FieldOption::default(42), FieldOption::orderAsc(), FieldOption::aliases('wrong', 'correct'))
    ->field('ignore', Schema::boolean(), FieldOption::orderIgnore())
    ->parse();
```