### PR TITLE
Add support for schema generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,72 @@ Schema::record()
     ->parse();
 ```
 
+## Schema generator
+
+Besides providing a fluent api for defining schemas, we also provide means of generating schema from 
+class metadata (annotations). For this to work, you have to install the `doctrine/annotations` package.
+
+```php
+<?php
+
+use FlixTech\AvroSerializer\Objects\DefaultSchemaGeneratorFactory;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroType("record")
+ * @SerDe\AvroName("user")
+ */
+class User
+{
+    /**
+     * @SerDe\AvroType("string")
+     * @var string
+     */
+    private $firstName;
+
+    /**
+     * @SerDe\AvroType("string")
+     * @var string
+     */
+    private $lastName;
+
+    /**
+     * @SerDe\AvroType("int")
+     * @var int
+     */
+    private $age;
+
+    public function __construct(string $firstName, string $lastName, int $age)
+    {
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+        $this->age = $age;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function getAge(): int
+    {
+        return $this->age;
+    }
+}
+
+$generator = DefaultSchemaGeneratorFactory::get();
+
+$schema = $generator->generate(User::class);
+$avroSchema = $schema->parse();
+```
+
+Further examples on the possible annotations can be seen in the [test case](test/Objects/Schema/Generation/SchemaGeneratorTest.php).
+
 ## Examples
 
 This library provides a few executable examples in the [examples](examples) folder. You should have a look to get an

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,11 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~7.0,<8.0",
-    "phpstan/phpstan": "^0.12",
+    "phpstan/phpstan": "^0.12.24",
     "phpbench/phpbench": "~0.9",
     "vlucas/phpdotenv": "~2.4",
-    "symfony/serializer": "^3.4|^4.3"
+    "symfony/serializer": "^3.4|^4.3",
+    "doctrine/annotations": "^1.10"
   },
   "autoload": {
     "psr-4": {
@@ -48,7 +49,8 @@
     ]
   },
   "suggest": {
-    "symfony/serializer": "To integrate avro-serde-php into symfony ecosystem"
+    "symfony/serializer": "To integrate avro-serde-php into symfony ecosystem",
+    "doctrine/annotations": "To enable the generation of avro schemas from annotations"
   },
   "autoload-dev": {
     "psr-4": {

--- a/examples/SchemaGenerator.php
+++ b/examples/SchemaGenerator.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Examples;
+
+use Dotenv\Dotenv;
+use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder;
+use FlixTech\AvroSerializer\Objects\DefaultRecordSerializerFactory;
+use FlixTech\AvroSerializer\Objects\DefaultSchemaGeneratorFactory;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
+use Symfony\Component\Serializer\Serializer;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$dotEnv = new Dotenv(__DIR__ . '/..');
+$dotEnv->load();
+$dotEnv->required('SCHEMA_REGISTRY_HOST')->notEmpty();
+
+/**
+ * @SerDe\AvroType("record")
+ * @SerDe\AvroName("user")
+ */
+class WriterUser
+{
+    /**
+     * @SerDe\AvroType("string")
+     * @var string
+     */
+    private $firstName;
+
+    /**
+     * @SerDe\AvroType("string")
+     * @var string
+     */
+    private $lastName;
+
+    /**
+     * @SerDe\AvroType("int")
+     * @var int
+     */
+    private $age;
+
+    public function __construct(string $firstName, string $lastName, int $age)
+    {
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+        $this->age = $age;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function getAge(): int
+    {
+        return $this->age;
+    }
+}
+
+/**
+ * @SerDe\AvroType("record")
+ * @SerDe\AvroName("user")
+ */
+class ReaderUser
+{
+    /**
+     * @SerDe\AvroType("string")
+     * @var string
+     */
+    private $firstName;
+
+    /**
+     * @SerDe\AvroType("int")
+     * @var int
+     */
+    private $age;
+
+    public function __construct(string $firstName, int $age)
+    {
+        $this->firstName = $firstName;
+        $this->age = $age;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getAge(): int
+    {
+        return $this->age;
+    }
+}
+
+$recordSerializer = DefaultRecordSerializerFactory::get(getenv('SCHEMA_REGISTRY_HOST'));
+$schemaGenerator = DefaultSchemaGeneratorFactory::get();
+
+$user = new WriterUser('Francisco', 'Rodrigues', 42);
+
+echo "User object to be serialized:\n";
+echo \var_export($user, true) . "\n\n";
+
+$normalizer = new PropertyNormalizer();
+$encoder = new AvroSerDeEncoder($recordSerializer);
+
+$symfonySerializer = new Serializer([$normalizer], [$encoder]);
+
+$serialized = $symfonySerializer->serialize(
+    $user,
+    AvroSerDeEncoder::FORMAT_AVRO,
+    [
+        AvroSerDeEncoder::CONTEXT_ENCODE_SUBJECT => 'users-value',
+        AvroSerDeEncoder::CONTEXT_ENCODE_WRITERS_SCHEMA => $schemaGenerator->generate(WriterUser::class)->parse(),
+    ]
+);
+
+echo "Confluent Avro wire format serialized binary as hex:\n";
+echo bin2hex($serialized) . "\n\n";
+
+/** @var ReaderUser $deserializedUser */
+$deserializedUser = $symfonySerializer->deserialize($serialized, ReaderUser::class, AvroSerDeEncoder::FORMAT_AVRO, [
+    AvroSerDeEncoder::CONTEXT_DECODE_READERS_SCHEMA => $schemaGenerator->generate(ReaderUser::class)->parse(),
+]);
+
+echo "Deserialized User:\n";
+echo \var_export($deserializedUser, true) . "\n";
+
+Assert::assertEquals(
+    $user->getFirstName(),
+    $deserializedUser->getFirstName()
+);
+
+Assert::assertEquals(
+    $user->getAge(),
+    $deserializedUser->getAge()
+);

--- a/src/Objects/DefaultSchemaGeneratorFactory.php
+++ b/src/Objects/DefaultSchemaGeneratorFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaGenerator;
+
+class DefaultSchemaGeneratorFactory
+{
+    public static function get(): SchemaGenerator
+    {
+        AnnotationRegistry::registerLoader('class_exists');
+
+        return new Schema\Generation\SchemaGenerator(
+            new Schema\Generation\AnnotationReader(
+                new AnnotationReader()
+            )
+        );
+    }
+}

--- a/src/Objects/Schema/ArrayType.php
+++ b/src/Objects/Schema/ArrayType.php
@@ -10,12 +10,12 @@ class ArrayType extends ComplexType
 {
     public function __construct()
     {
-        parent::__construct('array');
+        parent::__construct(TypeName::ARRAY);
     }
 
     public function items(Schema $schema): self
     {
-        return $this->attribute('items', $schema);
+        return $this->attribute(AttributeName::ITEMS, $schema);
     }
 
     /**
@@ -23,6 +23,6 @@ class ArrayType extends ComplexType
      */
     public function default(array $default): self
     {
-        return $this->attribute('default', $default);
+        return $this->attribute(AttributeName::DEFAULT, $default);
     }
 }

--- a/src/Objects/Schema/AttributeName.php
+++ b/src/Objects/Schema/AttributeName.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class AttributeName
+{
+    public const ALIASES = 'aliases';
+    public const DEFAULT = 'default';
+    public const DOC = 'doc';
+    public const ITEMS = 'items';
+    public const NAME = 'name';
+    public const NAMESPACE = 'namespace';
+    public const ORDER = 'order';
+    public const SIZE = 'size';
+    public const SYMBOLS = 'symbols';
+    public const TARGET_CLASS = 'targetClass';
+    public const TYPE = 'type';
+    public const VALUES = 'values';
+    public const LOGICAL_TYPE = 'logicalType';
+    public const FIELDS = 'fields';
+}

--- a/src/Objects/Schema/BooleanType.php
+++ b/src/Objects/Schema/BooleanType.php
@@ -8,6 +8,6 @@ class BooleanType extends PrimitiveType
 {
     public function __construct()
     {
-        parent::__construct('boolean');
+        parent::__construct(TypeName::BOOLEAN);
     }
 }

--- a/src/Objects/Schema/BytesType.php
+++ b/src/Objects/Schema/BytesType.php
@@ -8,6 +8,6 @@ class BytesType extends PrimitiveType
 {
     public function __construct()
     {
-        parent::__construct('bytes');
+        parent::__construct(TypeName::BYTES);
     }
 }

--- a/src/Objects/Schema/DateType.php
+++ b/src/Objects/Schema/DateType.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace FlixTech\AvroSerializer\Objects\Schema;
 
-use FlixTech\AvroSerializer\Objects\Schema;
-
 class DateType extends LogicalType
 {
     public function __construct()
     {
         parent::__construct(
-            'date',
-            Schema::int()->serialize()
+            TypeName::DATE,
+            TypeName::INT
         );
     }
 }

--- a/src/Objects/Schema/DoubleType.php
+++ b/src/Objects/Schema/DoubleType.php
@@ -8,6 +8,6 @@ class DoubleType extends PrimitiveType
 {
     public function __construct()
     {
-        parent::__construct('double');
+        parent::__construct(TypeName::DOUBLE);
     }
 }

--- a/src/Objects/Schema/DurationType.php
+++ b/src/Objects/Schema/DurationType.php
@@ -8,25 +8,27 @@ class DurationType extends LogicalType
 {
     public function __construct()
     {
-        parent::__construct('duration', 'fixed', [
-            'size' => 12,
-        ]);
+        parent::__construct(
+            TypeName::DURATION,
+            TypeName::FIXED,
+            ['size' => 12]
+        );
     }
 
     public function name(string $name): self
     {
-        return $this->attribute('name', $name);
+        return $this->attribute(AttributeName::NAME, $name);
     }
 
     public function namespace(string $namespace): self
     {
-        return $this->attribute('namespace', $namespace);
+        return $this->attribute(AttributeName::NAMESPACE, $namespace);
     }
 
     public function aliases(string $alias, string ...$aliases): self
     {
         \array_unshift($aliases, $alias);
 
-        return $this->attribute('aliases', $aliases);
+        return $this->attribute(AttributeName::ALIASES, $aliases);
     }
 }

--- a/src/Objects/Schema/EnumType.php
+++ b/src/Objects/Schema/EnumType.php
@@ -8,40 +8,40 @@ class EnumType extends ComplexType
 {
     public function __construct()
     {
-        parent::__construct('enum');
+        parent::__construct(TypeName::ENUM);
     }
 
     public function name(string $name): self
     {
-        return $this->attribute('name', $name);
+        return $this->attribute(AttributeName::NAME, $name);
     }
 
     public function namespace(string $namespace): self
     {
-        return $this->attribute('namespace', $namespace);
+        return $this->attribute(AttributeName::NAMESPACE, $namespace);
     }
 
     public function aliases(string $alias, string ...$aliases): self
     {
         \array_unshift($aliases, $alias);
 
-        return $this->attribute('aliases', $aliases);
+        return $this->attribute(AttributeName::ALIASES, $aliases);
     }
 
     public function doc(string $doc): self
     {
-        return $this->attribute('doc', $doc);
+        return $this->attribute(AttributeName::DOC, $doc);
     }
 
     public function symbols(string $symbol, string ...$symbols): self
     {
         \array_unshift($symbols, $symbol);
 
-        return $this->attribute('symbols', $symbols);
+        return $this->attribute(AttributeName::SYMBOLS, $symbols);
     }
 
     public function default(string $default): self
     {
-        return $this->attribute('default', $default);
+        return $this->attribute(AttributeName::DEFAULT, $default);
     }
 }

--- a/src/Objects/Schema/FixedType.php
+++ b/src/Objects/Schema/FixedType.php
@@ -8,28 +8,28 @@ class FixedType extends ComplexType
 {
     public function __construct()
     {
-        parent::__construct('fixed');
+        parent::__construct(TypeName::FIXED);
     }
 
     public function namespace(string $namespace): self
     {
-        return $this->attribute('namespace', $namespace);
+        return $this->attribute(AttributeName::NAMESPACE, $namespace);
     }
 
     public function name(string $name): self
     {
-        return $this->attribute('name', $name);
+        return $this->attribute(AttributeName::NAME, $name);
     }
 
     public function size(int $size): self
     {
-        return $this->attribute('size', $size);
+        return $this->attribute(AttributeName::SIZE, $size);
     }
 
     public function aliases(string $alias, string ...$aliases): self
     {
         \array_unshift($aliases, $alias);
 
-        return $this->attribute('aliases', $aliases);
+        return $this->attribute(AttributeName::ALIASES, $aliases);
     }
 }

--- a/src/Objects/Schema/FloatType.php
+++ b/src/Objects/Schema/FloatType.php
@@ -8,6 +8,6 @@ class FloatType extends PrimitiveType
 {
     public function __construct()
     {
-        parent::__construct('float');
+        parent::__construct(TypeName::FLOAT);
     }
 }

--- a/src/Objects/Schema/Generation/AnnotationReader.php
+++ b/src/Objects/Schema/Generation/AnnotationReader.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
+use ReflectionClass;
+use ReflectionProperty;
+
+class AnnotationReader implements SchemaAttributeReader
+{
+    /**
+     * @var DoctrineAnnotationReader
+     */
+    private $reader;
+
+    public function __construct(DoctrineAnnotationReader $reader)
+    {
+        $this->reader = $reader;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function readClassAttributes(ReflectionClass $class): SchemaAttributes
+    {
+        $annotations = $this->reader->getClassAnnotations($class);
+        $attributes = \array_filter($annotations, [$this, 'onlySchemaAttributes']);
+
+        return new SchemaAttributes(...$attributes);
+    }
+
+    public function readPropertyAttributes(ReflectionProperty $property): SchemaAttributes
+    {
+        $annotations = $this->reader->getPropertyAnnotations($property);
+        $attributes = \array_filter($annotations, [$this, 'onlySchemaAttributes']);
+
+        return new SchemaAttributes(...$attributes);
+    }
+
+    private function onlySchemaAttributes(object $annotation): bool
+    {
+        return $annotation instanceof SchemaAttribute;
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroAliases.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroAliases.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+final class AvroAliases implements SchemaAttribute
+{
+    /**
+     * @var array<string>
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return AttributeName::ALIASES;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return array<string>
+     */
+    public function value(): array
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes();
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroDefault.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroDefault.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+final class AvroDefault implements SchemaAttribute
+{
+    /**
+     * @var mixed
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return AttributeName::DEFAULT;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function value()
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes();
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroDoc.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroDoc.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+final class AvroDoc implements SchemaAttribute
+{
+    /**
+     * @var string
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return AttributeName::DOC;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes();
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroItems.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroItems.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+final class AvroItems implements SchemaAttribute
+{
+    /**
+     * @var string
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return AttributeName::ITEMS;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes();
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroName.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroName.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+class AvroName implements SchemaAttribute
+{
+    /**
+     * @var string
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return AttributeName::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes();
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroNamespace.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroNamespace.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+class AvroNamespace implements SchemaAttribute
+{
+    /**
+     * @var string
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return AttributeName::NAMESPACE;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes();
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroOrder.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroOrder.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+final class AvroOrder implements SchemaAttribute
+{
+    /**
+     * @var string
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return AttributeName::ORDER;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes();
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroSize.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroSize.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+final class AvroSize implements SchemaAttribute
+{
+    /**
+     * @var int
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return AttributeName::SIZE;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function value(): int
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes();
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroSymbols.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroSymbols.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+final class AvroSymbols implements SchemaAttribute
+{
+    /**
+     * @var array<string>
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return AttributeName::SYMBOLS;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return array<string>
+     */
+    public function value(): array
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes();
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroTargetClass.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroTargetClass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+final class AvroTargetClass implements SchemaAttribute
+{
+    /**
+     * @var string
+     */
+    public $value;
+
+    public function name(): string
+    {
+        return AttributeName::TARGET_CLASS;
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes();
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroType.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroType.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+final class AvroType implements SchemaAttribute
+{
+    /**
+     * @var string
+     */
+    public $value;
+
+    /**
+     * @var array<\FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute>
+     */
+    public $attributes = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return AttributeName::TYPE;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes(...$this->attributes);
+    }
+}

--- a/src/Objects/Schema/Generation/Annotations/AvroValues.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroValues.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+/**
+ * @Annotation
+ */
+final class AvroValues implements SchemaAttribute
+{
+    /**
+     * @var string
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return AttributeName::VALUES;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes();
+    }
+}

--- a/src/Objects/Schema/Generation/SchemaAttribute.php
+++ b/src/Objects/Schema/Generation/SchemaAttribute.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+interface SchemaAttribute
+{
+    public function name(): string;
+
+    /**
+     * @return mixed
+     */
+    public function value();
+
+    public function attributes(): SchemaAttributes;
+}

--- a/src/Objects/Schema/Generation/SchemaAttributeReader.php
+++ b/src/Objects/Schema/Generation/SchemaAttributeReader.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+use ReflectionClass;
+use ReflectionProperty;
+
+interface SchemaAttributeReader
+{
+    /**
+     * @param ReflectionClass<object> $class
+     */
+    public function readClassAttributes(ReflectionClass $class): SchemaAttributes;
+
+    public function readPropertyAttributes(ReflectionProperty $property): SchemaAttributes;
+}

--- a/src/Objects/Schema/Generation/SchemaAttributes.php
+++ b/src/Objects/Schema/Generation/SchemaAttributes.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+
+class SchemaAttributes implements \Countable
+{
+    /**
+     * @var array<string, array<SchemaAttribute>>
+     */
+    private $attributes = [];
+
+    /**
+     * @var array<SchemaAttribute>
+     */
+    private $optionAttributes = [];
+
+    public function __construct(SchemaAttribute ...$attributes)
+    {
+        foreach ($attributes as $attribute) {
+            $this->add($attribute);
+        }
+    }
+
+    /**
+     * @return array<SchemaAttribute>
+     */
+    public function types(): array
+    {
+        return $this->attributes[AttributeName::TYPE] ?? [];
+    }
+
+    /**
+     * @return array<SchemaAttribute>
+     */
+    public function options(): array
+    {
+        return $this->optionAttributes;
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->attributes[$name]);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function get(string $name)
+    {
+        return $this->attributes[$name][0]->value();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count(): int
+    {
+        return \count($this->attributes);
+    }
+
+    private function add(SchemaAttribute $attribute): void
+    {
+        $this->attributes[$attribute->name()][] = $attribute;
+
+        if (AttributeName::TYPE !== $attribute->name()) {
+            $this->optionAttributes[] = $attribute;
+        }
+    }
+}

--- a/src/Objects/Schema/Generation/SchemaGenerator.php
+++ b/src/Objects/Schema/Generation/SchemaGenerator.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Record\FieldOrder;
+use FlixTech\AvroSerializer\Objects\Schema\TypeName;
+use ReflectionClass;
+use ReflectionProperty;
+
+class SchemaGenerator
+{
+    /**
+     * @var SchemaAttributeReader
+     */
+    private $reader;
+
+    public function __construct(SchemaAttributeReader $reader)
+    {
+        $this->reader = $reader;
+    }
+
+    /**
+     * @param class-string<object> $className
+     */
+    public function generate(string $className): Schema
+    {
+        $class = new ReflectionClass($className);
+        $attributes = $this->reader->readClassAttributes($class);
+
+        return $this->generateFromClass($class, $attributes);
+    }
+
+    /**
+     * @param ReflectionClass<object> $class
+     */
+    private function generateFromClass(ReflectionClass $class, SchemaAttributes $attributes): Schema
+    {
+        $type = $attributes->types()[0];
+        $schema = $this->schemaFromType($type->value(), $attributes);
+
+        if (!$schema instanceof Schema\RecordType) {
+            return $schema;
+        }
+
+        foreach ($class->getProperties() as $property) {
+            /** @var Schema\RecordType $schema */
+            $schema = $this->parseField($property, $schema);
+        }
+
+        return $schema;
+    }
+
+    private function schemaFromType(string $type, SchemaAttributes $attributes): Schema
+    {
+        switch ($type) {
+            case TypeName::RECORD:
+                if ($attributes->has(AttributeName::TARGET_CLASS)) {
+                    return $this->generate($attributes->get(AttributeName::TARGET_CLASS));
+                }
+                $schema = Schema::record();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::NULL:
+                $schema = Schema::null();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::BOOLEAN:
+                $schema = Schema::boolean();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::INT:
+                $schema = Schema::int();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::LONG:
+                $schema = Schema::long();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::FLOAT:
+                $schema = Schema::float();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::DOUBLE:
+                $schema = Schema::double();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::BYTES:
+                $schema = Schema::bytes();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::STRING:
+                $schema = Schema::string();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::ARRAY:
+                $schema = Schema::array();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::MAP:
+                $schema = Schema::map();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::ENUM:
+                $schema = Schema::enum();
+
+                return $this->applyAttributes($schema, $attributes);
+            case TypeName::FIXED:
+                $schema = Schema::fixed();
+
+                return $this->applyAttributes($schema, $attributes);
+            default:
+                throw new \InvalidArgumentException('$type is not a valid avro type');
+        }
+    }
+
+    private function parseField(ReflectionProperty $property, Schema\RecordType $rootSchema): Schema
+    {
+        $attributes = $this->reader->readPropertyAttributes($property);
+
+        if (0 === \count($attributes)) {
+            return $rootSchema;
+        }
+
+        $mainType = $attributes->types()[0];
+        $fieldSchema = $this->schemaFromType($mainType->value(), $mainType->attributes());
+
+        if (1 < \count($attributes->types())) {
+            $unionSchemas = \array_map(function (SchemaAttribute $type) {
+                return $this->schemaFromType($type->value(), $type->attributes());
+            }, $attributes->types());
+
+            $fieldSchema = Schema::union(...$unionSchemas);
+        }
+
+        $fieldArgs = [
+            $attributes->has(AttributeName::NAME) ? $attributes->get(AttributeName::NAME) : $property->getName(),
+            $fieldSchema,
+        ];
+
+        if ($attributes->has(AttributeName::DOC)) {
+            $fieldArgs[] = Schema\Record\FieldOption::doc($attributes->get(AttributeName::DOC));
+        }
+
+        if ($attributes->has(AttributeName::DEFAULT)) {
+            $fieldArgs[] = Schema\Record\FieldOption::default($attributes->get(AttributeName::DEFAULT));
+        }
+
+        if ($attributes->has(AttributeName::ORDER)) {
+            $fieldArgs[] = new FieldOrder($attributes->get(AttributeName::ORDER));
+        }
+
+        if ($attributes->has(AttributeName::ALIASES)) {
+            $fieldArgs[] = Schema\Record\FieldOption::aliases(
+                ...$attributes->get(AttributeName::ALIASES)
+            );
+        }
+
+        return $rootSchema
+            ->field(...$fieldArgs);
+    }
+
+    private function applyAttributes(Schema $schema, SchemaAttributes $attributes): Schema
+    {
+        $variadicValues = [
+            AttributeName::SYMBOLS,
+            AttributeName::ALIASES,
+        ];
+
+        $schemaValues = [
+            AttributeName::ITEMS,
+            AttributeName::VALUES,
+        ];
+
+        foreach ($attributes->options() as $attribute) {
+            if (\in_array($attribute->name(), $variadicValues) && \is_array($attribute->value())) {
+                $schema = $schema->{$attribute->name()}(...$attribute->value());
+
+                continue;
+            }
+
+            if (\in_array($attribute->name(), $schemaValues) && \is_string($attribute->value())) {
+                $schema = $schema->{$attribute->name()}($this->schemaFromType($attribute->value(), new SchemaAttributes()));
+
+                continue;
+            }
+
+            if (empty($attribute->name()) || AttributeName::TARGET_CLASS === $attribute->name()) {
+                continue;
+            }
+
+            $schema = $schema->{$attribute->name()}($attribute->value());
+        }
+
+        return $schema;
+    }
+}

--- a/src/Objects/Schema/IntType.php
+++ b/src/Objects/Schema/IntType.php
@@ -8,6 +8,6 @@ class IntType extends PrimitiveType
 {
     public function __construct()
     {
-        parent::__construct('int');
+        parent::__construct(TypeName::INT);
     }
 }

--- a/src/Objects/Schema/LocalTimestampMicros.php
+++ b/src/Objects/Schema/LocalTimestampMicros.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace FlixTech\AvroSerializer\Objects\Schema;
 
-use FlixTech\AvroSerializer\Objects\Schema;
-
 class LocalTimestampMicros extends LogicalType
 {
     public function __construct()
     {
-        parent::__construct('local-timestamp-micros', Schema::long()->serialize());
+        parent::__construct(TypeName::LOCAL_TIMESTAMP_MICROS, TypeName::LONG);
     }
 }

--- a/src/Objects/Schema/LocalTimestampMillisType.php
+++ b/src/Objects/Schema/LocalTimestampMillisType.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace FlixTech\AvroSerializer\Objects\Schema;
 
-use FlixTech\AvroSerializer\Objects\Schema;
-
 class LocalTimestampMillisType extends LogicalType
 {
     public function __construct()
     {
-        parent::__construct('local-timestamp-millis', Schema::long()->serialize());
+        parent::__construct(TypeName::LOCAL_TIMESTAMP_MILLIS, TypeName::LONG);
     }
 }

--- a/src/Objects/Schema/LogicalType.php
+++ b/src/Objects/Schema/LogicalType.php
@@ -11,7 +11,7 @@ abstract class LogicalType extends ComplexType
      */
     public function __construct(string $logicalType, string $annotatedType, array $attributes = [])
     {
-        $attributes['logicalType'] = $logicalType;
+        $attributes[AttributeName::LOGICAL_TYPE] = $logicalType;
 
         parent::__construct($annotatedType, $attributes);
     }

--- a/src/Objects/Schema/LongType.php
+++ b/src/Objects/Schema/LongType.php
@@ -8,6 +8,6 @@ class LongType extends PrimitiveType
 {
     public function __construct()
     {
-        parent::__construct('long');
+        parent::__construct(TypeName::LONG);
     }
 }

--- a/src/Objects/Schema/MapType.php
+++ b/src/Objects/Schema/MapType.php
@@ -10,12 +10,12 @@ class MapType extends ComplexType
 {
     public function __construct()
     {
-        parent::__construct('map');
+        parent::__construct(TypeName::MAP);
     }
 
     public function values(Schema $schema): self
     {
-        return $this->attribute('values', $schema);
+        return $this->attribute(AttributeName::VALUES, $schema);
     }
 
     /**
@@ -23,6 +23,6 @@ class MapType extends ComplexType
      */
     public function default(array $default): self
     {
-        return $this->attribute('default', $default);
+        return $this->attribute(AttributeName::DEFAULT, $default);
     }
 }

--- a/src/Objects/Schema/NullType.php
+++ b/src/Objects/Schema/NullType.php
@@ -8,6 +8,6 @@ class NullType extends PrimitiveType
 {
     public function __construct()
     {
-        parent::__construct('null');
+        parent::__construct(TypeName::NULL);
     }
 }

--- a/src/Objects/Schema/Record/FieldOrder.php
+++ b/src/Objects/Schema/Record/FieldOrder.php
@@ -6,7 +6,7 @@ namespace FlixTech\AvroSerializer\Objects\Schema\Record;
 
 class FieldOrder extends FieldOption
 {
-    private function __construct(string $order)
+    public function __construct(string $order)
     {
         parent::__construct('order', $order);
     }

--- a/src/Objects/Schema/RecordType.php
+++ b/src/Objects/Schema/RecordType.php
@@ -17,22 +17,22 @@ class RecordType extends ComplexType
 
     public function __construct()
     {
-        parent::__construct('record');
+        parent::__construct(TypeName::RECORD);
     }
 
     public function name(string $name): self
     {
-        return $this->attribute('name', $name);
+        return $this->attribute(AttributeName::NAME, $name);
     }
 
     public function namespace(string $namespace): self
     {
-        return $this->attribute('namespace', $namespace);
+        return $this->attribute(AttributeName::NAMESPACE, $namespace);
     }
 
     public function doc(string $doc): self
     {
-        return $this->attribute('doc', $doc);
+        return $this->attribute(AttributeName::DOC, $doc);
     }
 
     /**
@@ -40,7 +40,7 @@ class RecordType extends ComplexType
      */
     public function aliases(array $aliases): self
     {
-        return $this->attribute('aliases', $aliases);
+        return $this->attribute(AttributeName::ALIASES, $aliases);
     }
 
     public function field(string $name, Schema $type, FieldOption ...$options): self
@@ -58,7 +58,7 @@ class RecordType extends ComplexType
     {
         $record = parent::serialize();
 
-        $record['fields'] = \array_map(function (Field $field) {
+        $record[AttributeName::FIELDS] = \array_map(function (Field $field) {
             return $field->serialize();
         }, $this->fields);
 

--- a/src/Objects/Schema/StringType.php
+++ b/src/Objects/Schema/StringType.php
@@ -8,6 +8,6 @@ class StringType extends PrimitiveType
 {
     public function __construct()
     {
-        parent::__construct('string');
+        parent::__construct(TypeName::STRING);
     }
 }

--- a/src/Objects/Schema/TimeMicrosType.php
+++ b/src/Objects/Schema/TimeMicrosType.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace FlixTech\AvroSerializer\Objects\Schema;
 
-use FlixTech\AvroSerializer\Objects\Schema;
-
 class TimeMicrosType extends LogicalType
 {
     public function __construct()
     {
-        parent::__construct('time-micros', Schema::long()->serialize());
+        parent::__construct(TypeName::TIME_MICROS, TypeName::LONG);
     }
 }

--- a/src/Objects/Schema/TimeMillisType.php
+++ b/src/Objects/Schema/TimeMillisType.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace FlixTech\AvroSerializer\Objects\Schema;
 
-use FlixTech\AvroSerializer\Objects\Schema;
-
 class TimeMillisType extends LogicalType
 {
     public function __construct()
     {
-        parent::__construct('time-millis', Schema::int()->serialize());
+        parent::__construct(TypeName::TIME_MILLIS, TypeName::INT);
     }
 }

--- a/src/Objects/Schema/TimestampMicrosType.php
+++ b/src/Objects/Schema/TimestampMicrosType.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace FlixTech\AvroSerializer\Objects\Schema;
 
-use FlixTech\AvroSerializer\Objects\Schema;
-
 class TimestampMicrosType extends LogicalType
 {
     public function __construct()
     {
-        parent::__construct('timestamp-micros', Schema::long()->serialize());
+        parent::__construct(TypeName::TIMESTAMP_MICROS, TypeName::LONG);
     }
 }

--- a/src/Objects/Schema/TimestampMillisType.php
+++ b/src/Objects/Schema/TimestampMillisType.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace FlixTech\AvroSerializer\Objects\Schema;
 
-use FlixTech\AvroSerializer\Objects\Schema;
-
 class TimestampMillisType extends LogicalType
 {
     public function __construct()
     {
-        parent::__construct('timestamp-millis', Schema::long()->serialize());
+        parent::__construct(TypeName::TIMESTAMP_MILLIS, TypeName::LONG);
     }
 }

--- a/src/Objects/Schema/TypeName.php
+++ b/src/Objects/Schema/TypeName.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+class TypeName
+{
+    public const RECORD = 'record';
+    public const NULL = 'null';
+    public const BOOLEAN = 'boolean';
+    public const INT = 'int';
+    public const LONG = 'long';
+    public const FLOAT = 'float';
+    public const DOUBLE = 'double';
+    public const BYTES = 'bytes';
+    public const STRING = 'string';
+    public const ARRAY = 'array';
+    public const MAP = 'map';
+    public const ENUM = 'enum';
+    public const FIXED = 'fixed';
+    public const DATE = 'date';
+    public const DURATION = 'duration';
+    public const LOCAL_TIMESTAMP_MICROS = 'local-timestamp-micros';
+    public const LOCAL_TIMESTAMP_MILLIS = 'local-timestamp-millis';
+    public const TIME_MICROS = 'time-micros';
+    public const TIME_MILLIS = 'time-millis';
+    public const TIMESTAMP_MICROS = 'timestamp-micros';
+    public const TIMESTAMP_MILLIS = 'timestamp-millis';
+    public const UUID = 'uuid';
+}

--- a/src/Objects/Schema/UuidType.php
+++ b/src/Objects/Schema/UuidType.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace FlixTech\AvroSerializer\Objects\Schema;
 
-use FlixTech\AvroSerializer\Objects\Schema;
-
 class UuidType extends LogicalType
 {
     public function __construct()
     {
         parent::__construct(
-            'uuid',
-            Schema::string()->serialize()
+            TypeName::UUID,
+            TypeName::STRING
         );
     }
 }

--- a/test/Objects/Schema/Generation/Fixture/EmptyRecord.php
+++ b/test/Objects/Schema/Generation/Fixture/EmptyRecord.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroName("EmptyRecord")
+ * @SerDe\AvroNamespace("org.acme")
+ * @SerDe\AvroType("record")
+ */
+class EmptyRecord
+{
+}

--- a/test/Objects/Schema/Generation/Fixture/PrimitiveTypes.php
+++ b/test/Objects/Schema/Generation/Fixture/PrimitiveTypes.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroName("PrimitiveTypes")
+ * @SerDe\AvroNamespace("org.acme")
+ * @SerDe\AvroType("record")
+ */
+class PrimitiveTypes
+{
+    /**
+     * @SerDe\AvroDoc("null type")
+     * @SerDe\AvroType("null")
+     */
+    private $nullType;
+
+    /**
+     * @SerDe\AvroName("isItTrue")
+     * @SerDe\AvroDefault(false)
+     * @SerDe\AvroType("boolean")
+     */
+    private $booleanType;
+
+    /**
+     * @SerDe\AvroType("int")
+     */
+    private $intType;
+
+    /**
+     * @SerDe\AvroType("long")
+     * @SerDe\AvroOrder("ascending")
+     */
+    private $longType;
+
+    /**
+     * @SerDe\AvroType("float")
+     * @SerDe\AvroAliases({"foo", "bar"})
+     */
+    private $floatType;
+
+    /**
+     * @SerDe\AvroType("double")
+     */
+    private $doubleType;
+
+    /**
+     * @SerDe\AvroType("bytes")
+     */
+    private $bytesType;
+
+    /**
+     * @SerDe\AvroType("string")
+     */
+    private $stringType;
+}

--- a/test/Objects/Schema/Generation/Fixture/RecordWithComplexTypes.php
+++ b/test/Objects/Schema/Generation/Fixture/RecordWithComplexTypes.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroType("record")
+ * @SerDe\AvroName("RecordWithComplexTypes")
+ */
+class RecordWithComplexTypes
+{
+    /**
+     * @SerDe\AvroType("array", attributes={
+     *     @SerDe\AvroItems("string"),
+     *     @SerDe\AvroDefault({"foo", "bar"}),
+     * })
+     */
+    private $array;
+
+    /**
+     * @SerDe\AvroType("map", attributes={
+     *     @SerDe\AvroValues("int"),
+     *     @SerDe\AvroDefault({"foo": 42, "bar": 42}),
+     * })
+     */
+    private $map;
+
+    /**
+     * @SerDe\AvroOrder("ascending")
+     * @SerDe\AvroType("enum", attributes={
+     *     @SerDe\AvroName("Suit"),
+     *     @SerDe\AvroSymbols({"SPADES", "HEARTS", "DIAMONDS", "CLUBS"})
+     * })
+     */
+    private $enum;
+
+    /**
+     * @SerDe\AvroType("fixed", attributes={
+     *     @SerDe\AvroName("md5"),
+     *     @SerDe\AvroNamespace("org.acme"),
+     *     @SerDe\AvroAliases({"foo", "bar"}),
+     *     @SerDe\AvroSize(16)
+     * })
+     */
+    private $fixed;
+
+    /**
+     * @SerDe\AvroType("string")
+     * @SerDe\AvroType("int")
+     * @SerDe\AvroType("array", attributes={
+     *     @SerDe\AvroItems("string"),
+     * })
+     */
+    private $union;
+}

--- a/test/Objects/Schema/Generation/Fixture/RecordWithRecordType.php
+++ b/test/Objects/Schema/Generation/Fixture/RecordWithRecordType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroType("record")
+ * @SerDe\AvroName("RecordWithRecordType")
+ */
+class RecordWithRecordType
+{
+    /**
+     * @SerDe\AvroName("simple")
+     * @SerDe\AvroType("record", attributes={
+     *     @SerDe\AvroTargetClass("\FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\SimpleRecord")
+     * })
+     */
+    private $simpleRecord;
+}

--- a/test/Objects/Schema/Generation/Fixture/SimpleRecord.php
+++ b/test/Objects/Schema/Generation/Fixture/SimpleRecord.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroName("SimpleRecord")
+ * @SerDe\AvroNamespace("org.acme")
+ * @SerDe\AvroType("record")
+ */
+class SimpleRecord
+{
+    /**
+     * @SerDe\AvroType("int")
+     * @SerDe\AvroDefault(42)
+     */
+    private $intType;
+}

--- a/test/Objects/Schema/Generation/SchemaGeneratorTest.php
+++ b/test/Objects/Schema/Generation/SchemaGeneratorTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use FlixTech\AvroSerializer\Objects\Schema;
+use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\EmptyRecord;
+use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\PrimitiveTypes;
+use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\RecordWithComplexTypes;
+use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\RecordWithRecordType;
+use PHPUnit\Framework\TestCase;
+
+class SchemaGeneratorTest extends TestCase
+{
+    /**
+     * @var Schema\Generation\SchemaGenerator
+     */
+    private $generator;
+
+    protected function setUp()
+    {
+        AnnotationRegistry::registerLoader('class_exists');
+
+        $this->generator = new Schema\Generation\SchemaGenerator(
+            new Schema\Generation\AnnotationReader(
+                new AnnotationReader()
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_an_empty_record()
+    {
+        $schema = $this->generator->generate(EmptyRecord::class);
+
+        $expected = Schema::record()
+            ->name('EmptyRecord')
+            ->namespace('org.acme');
+
+        $this->assertEquals($expected, $schema);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_a_record_schema_with_primitive_types()
+    {
+        $schema = $this->generator->generate(PrimitiveTypes::class);
+
+        $expected = Schema::record()
+            ->name('PrimitiveTypes')
+            ->namespace('org.acme')
+            ->field(
+                'nullType',
+                Schema::null(),
+                Schema\Record\FieldOption::doc('null type')
+            )
+            ->field(
+                'isItTrue',
+                Schema::boolean(),
+                Schema\Record\FieldOption::default(false)
+            )
+            ->field(
+                'intType',
+                Schema::int()
+            )
+            ->field(
+                'longType',
+                Schema::long(),
+                Schema\Record\FieldOption::orderAsc()
+            )
+            ->field(
+                'floatType',
+                Schema::float(),
+                Schema\Record\FieldOption::aliases('foo', 'bar')
+            )
+            ->field(
+                'doubleType',
+                Schema::double()
+            )
+            ->field(
+                'bytesType',
+                Schema::bytes()
+            )
+            ->field(
+                'stringType',
+                Schema::string()
+            );
+
+        $this->assertEquals($expected, $schema);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_a_schema_record_with_complex_types()
+    {
+        $schema = $this->generator->generate(RecordWithComplexTypes::class);
+
+        $expected = Schema::record()
+            ->name('RecordWithComplexTypes')
+            ->field(
+                'array',
+                Schema::array()
+                    ->items(Schema::string())
+                    ->default(['foo', 'bar'])
+            )
+            ->field(
+                'map',
+                Schema::map()
+                    ->values(Schema::int())
+                    ->default(['foo' => 42, 'bar' => 42])
+            )
+            ->field(
+                'enum',
+                Schema::enum()
+                    ->name('Suit')
+                    ->symbols('SPADES', 'HEARTS', 'DIAMONDS', 'CLUBS'),
+                Schema\Record\FieldOrder::asc()
+            )
+            ->field(
+                'fixed',
+                Schema::fixed()
+                    ->name('md5')
+                    ->namespace('org.acme')
+                    ->aliases('foo', 'bar')
+                    ->size(16)
+            )
+            ->field(
+                'union',
+                Schema::union(Schema::string(), Schema::int(), Schema::array()->items(Schema::string()))
+            );
+
+        $this->assertEquals($expected, $schema);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_records_containing_records()
+    {
+        $schema = $this->generator->generate(RecordWithRecordType::class);
+
+        $expected = Schema::record()
+            ->name('RecordWithRecordType')
+            ->field(
+                'simple',
+                Schema::record()
+                    ->name('SimpleRecord')
+                    ->namespace('org.acme')
+                    ->field('intType', Schema::int(), Schema\Record\FieldOption::default(42))
+            );
+
+        $this->assertEquals($expected, $schema);
+    }
+}


### PR DESCRIPTION
## Overview

This PR adds up to my [last one](https://github.com/flix-tech/avro-serde-php/pull/35) by enabling us to generate schemas from class metadata.

I've also defined two interfaces: SchemaAttributeReader and SchemaAttribute. The goal here is to enable the support for [php8 attributes](https://wiki.php.net/rfc/attributes_v2) in the future.

It supports complex types, logical types and primitive types. It also supports defining nested records. Here a sample usage:

```php
<?php

use FlixTech\AvroSerializer\Objects\DefaultSchemaGeneratorFactory;
use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;

/**
 * @SerDe\AvroType("record")
 * @SerDe\AvroName("user")
 */
class User
{
    /**
     * @SerDe\AvroType("string")
     * @var string
     */
    private $firstName;

    /**
     * @SerDe\AvroType("string")
     * @var string
     */
    private $lastName;

    /**
     * @SerDe\AvroType("int")
     * @var int
     */
    private $age;

    public function __construct(string $firstName, string $lastName, int $age)
    {
        $this->firstName = $firstName;
        $this->lastName = $lastName;
        $this->age = $age;
    }

    public function getFirstName(): string
    {
        return $this->firstName;
    }

    public function getLastName(): string
    {
        return $this->lastName;
    }

    public function getAge(): int
    {
        return $this->age;
    }
}

$generator = DefaultSchemaGeneratorFactory::get();

$schema = $generator->generate(User::class);
$avroSchema = $schema->parse();
```

Further examples can be seen in the test cases.

## Improvements

Here a list of possible future improvements:

 * Infer field types from class type annotations and/or type hints (php 7.4). Today, we need to be explicit about the types of each field, which can be a little redudant sometimes.
 * Add support for php8 attributes.