### PR TITLE
Depend upon Reader interface

### DIFF
--- a/src/Objects/Schema/Generation/AnnotationReader.php
+++ b/src/Objects/Schema/Generation/AnnotationReader.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
 
-use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
+use Doctrine\Common\Annotations\Reader as DoctrineAnnotationReader;
 use ReflectionClass;
 use ReflectionProperty;
 


### PR DESCRIPTION
The AnnotationReader implementation is depending upon the doctrine
AnnotationReader concrete class. This is not ideal as it prevents us
from using the CachedReader.

Replace dependency upon the concrete AnnotationReader class with the
Reader interface.