### PR TITLE
Improve schema generation with annotations

### DIFF
--- a/src/Objects/Schema/Generation/Annotations/AvroAliases.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroAliases.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
 
 use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
 use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\VariadicAttribute;
 
 /**
  * @Annotation
  */
-final class AvroAliases implements SchemaAttribute
+final class AvroAliases implements VariadicAttribute
 {
     /**
      * @var array<string>

--- a/src/Objects/Schema/Generation/Annotations/AvroItems.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroItems.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
 
 use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\TypeOnlyAttribute;
 
 /**
  * @Annotation
  */
-final class AvroItems implements SchemaAttribute
+final class AvroItems implements TypeOnlyAttribute
 {
-    /**
-     * @var string
-     */
-    public $value;
+    use ContainsOnlyTypes;
 
     /**
      * {@inheritdoc}
@@ -24,21 +20,5 @@ final class AvroItems implements SchemaAttribute
     public function name(): string
     {
         return AttributeName::ITEMS;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function value(): string
-    {
-        return $this->value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function attributes(): SchemaAttributes
-    {
-        return new SchemaAttributes();
     }
 }

--- a/src/Objects/Schema/Generation/Annotations/AvroSymbols.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroSymbols.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
 
 use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
 use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\VariadicAttribute;
 
 /**
  * @Annotation
  */
-final class AvroSymbols implements SchemaAttribute
+final class AvroSymbols implements VariadicAttribute
 {
     /**
      * @var array<string>

--- a/src/Objects/Schema/Generation/Annotations/AvroType.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroType.php
@@ -23,6 +23,16 @@ final class AvroType implements SchemaAttribute
      */
     public $attributes = [];
 
+    public static function create(string $typeName, SchemaAttribute ...$attributes): self
+    {
+        $avroType = new self();
+
+        $avroType->value = $typeName;
+        $avroType->attributes = $attributes;
+
+        return $avroType;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Objects/Schema/Generation/Annotations/AvroValues.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroValues.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
 
 use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\TypeOnlyAttribute;
 
 /**
  * @Annotation
  */
-final class AvroValues implements SchemaAttribute
+final class AvroValues implements TypeOnlyAttribute
 {
-    /**
-     * @var string
-     */
-    public $value;
+    use ContainsOnlyTypes;
 
     /**
      * {@inheritdoc}
@@ -24,21 +20,5 @@ final class AvroValues implements SchemaAttribute
     public function name(): string
     {
         return AttributeName::VALUES;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function value(): string
-    {
-        return $this->value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function attributes(): SchemaAttributes
-    {
-        return new SchemaAttributes();
     }
 }

--- a/src/Objects/Schema/Generation/Annotations/ContainsOnlyTypes.php
+++ b/src/Objects/Schema/Generation/Annotations/ContainsOnlyTypes.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+trait ContainsOnlyTypes
+{
+    /**
+     * @phpstan-var string|AvroType|array<string|AvroType>
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return array<SchemaAttribute>
+     */
+    public function value(): array
+    {
+        if (!\is_array($this->value)) {
+            return [$this->valueToType($this->value)];
+        }
+
+        return \array_map([$this, 'valueToType'], $this->value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes(...$this->value());
+    }
+
+    /**
+     * @param string|AvroType $value
+     */
+    private function valueToType($value): AvroType
+    {
+        if ($value instanceof AvroType) {
+            return $value;
+        }
+
+        return AvroType::create($value);
+    }
+}

--- a/src/Objects/Schema/Generation/SchemaAttributes.php
+++ b/src/Objects/Schema/Generation/SchemaAttributes.php
@@ -26,11 +26,16 @@ class SchemaAttributes implements \Countable
     }
 
     /**
-     * @return array<SchemaAttribute>
+     * @return array<Type>
      */
     public function types(): array
     {
-        return $this->attributes[AttributeName::TYPE] ?? [];
+        return \array_map(function (SchemaAttribute $schemaAttribute) {
+            return new Type(
+                $schemaAttribute->value(),
+                $schemaAttribute->attributes()
+            );
+        }, $this->attributes[AttributeName::TYPE] ?? []);
     }
 
     /**

--- a/src/Objects/Schema/Generation/Type.php
+++ b/src/Objects/Schema/Generation/Type.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+class Type
+{
+    /**
+     * @var string
+     */
+    private $typeName;
+
+    /**
+     * @var SchemaAttributes
+     */
+    private $attributes;
+
+    public function __construct(string $typeName, SchemaAttributes $attributes = null)
+    {
+        $this->typeName = $typeName;
+        $this->attributes = $attributes ?? new SchemaAttributes();
+    }
+
+    public function getTypeName(): string
+    {
+        return $this->typeName;
+    }
+
+    public function getAttributes(): SchemaAttributes
+    {
+        return $this->attributes;
+    }
+}

--- a/src/Objects/Schema/Generation/TypeOnlyAttribute.php
+++ b/src/Objects/Schema/Generation/TypeOnlyAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+/**
+ * Marker interface to indicate that the attribute contains only type attributes
+ */
+interface TypeOnlyAttribute extends SchemaAttribute
+{
+}

--- a/src/Objects/Schema/Generation/VariadicAttribute.php
+++ b/src/Objects/Schema/Generation/VariadicAttribute.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+/**
+ * Marker interface to indicate that the attribute contains variadic values
+ */
+interface VariadicAttribute extends SchemaAttribute
+{
+    /**
+     * @return array<mixed>
+     */
+    public function value(): array;
+}

--- a/test/Objects/Schema/Generation/Fixture/ArraysWithComplexType.php
+++ b/test/Objects/Schema/Generation/Fixture/ArraysWithComplexType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroType("record")
+ * @SerDe\AvroName("ArraysWithComplexType")
+ */
+class ArraysWithComplexType
+{
+    /**
+     * @SerDe\AvroType("array", attributes={
+     *     @SerDe\AvroItems({
+     *         "string",
+     *         @SerDe\AvroType("array", attributes={@SerDe\AvroItems(@SerDe\AvroType("string"))})
+     *     })
+     * })
+     */
+    private $arrayWithUnion;
+
+    /**
+     * @SerDe\AvroType("array", attributes={
+     *     @SerDe\AvroItems(
+     *         @SerDe\AvroType("map", attributes={@SerDe\AvroValues(@SerDe\AvroType("string"))})
+     *     )
+     * })
+     */
+    private $arrayWithMap;
+}

--- a/test/Objects/Schema/Generation/Fixture/MapsWithComplexType.php
+++ b/test/Objects/Schema/Generation/Fixture/MapsWithComplexType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroType("record")
+ * @SerDe\AvroName("MapsWithComplexType")
+ */
+class MapsWithComplexType
+{
+    /**
+     * @SerDe\AvroType("map", attributes={
+     *     @SerDe\AvroValues({
+     *         "string",
+     *         @SerDe\AvroType("array", attributes={@SerDe\AvroItems("string")})
+     *     })
+     * })
+     */
+    private $mapWithUnion;
+
+    /**
+     * @SerDe\AvroType("map", attributes={
+     *     @SerDe\AvroValues(
+     *         @SerDe\AvroType("array", attributes={@SerDe\AvroItems("string")})
+     *     )
+     * })
+     */
+    private $mapWithArray;
+}

--- a/test/Objects/Schema/Generation/SchemaGeneratorTest.php
+++ b/test/Objects/Schema/Generation/SchemaGeneratorTest.php
@@ -7,7 +7,9 @@ namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use FlixTech\AvroSerializer\Objects\Schema;
+use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\ArraysWithComplexType;
 use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\EmptyRecord;
+use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\MapsWithComplexType;
 use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\PrimitiveTypes;
 use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\RecordWithComplexTypes;
 use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\RecordWithRecordType;
@@ -154,6 +156,66 @@ class SchemaGeneratorTest extends TestCase
                     ->name('SimpleRecord')
                     ->namespace('org.acme')
                     ->field('intType', Schema::int(), Schema\Record\FieldOption::default(42))
+            );
+
+        $this->assertEquals($expected, $schema);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_a_record_schema_with_arrays_containing_complex_types()
+    {
+        $schema = $this->generator->generate(ArraysWithComplexType::class);
+
+        $expected = Schema::record()
+            ->name('ArraysWithComplexType')
+            ->field(
+                'arrayWithUnion',
+                Schema::array()
+                    ->items(
+                        Schema::union(
+                            Schema::string(),
+                            Schema::array()->items(Schema::string())
+                        )
+                    )
+            )
+            ->field(
+                'arrayWithMap',
+                Schema::array()
+                    ->items(
+                        Schema::map()->values(Schema::string())
+                    )
+            );
+
+        $this->assertEquals($expected, $schema);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_a_record_schema_with_maps_containing_complex_types()
+    {
+        $schema = $this->generator->generate(MapsWithComplexType::class);
+
+        $expected = Schema::record()
+            ->name('MapsWithComplexType')
+            ->field(
+                'mapWithUnion',
+                Schema::map()
+                    ->values(
+                        Schema::union(
+                            Schema::string(),
+                            Schema::array()->items(Schema::string())
+                        )
+                    )
+            )
+            ->field(
+                'mapWithArray',
+                Schema::map()
+                    ->values(
+                        Schema::array()->items(Schema::string())
+                    )
             );
 
         $this->assertEquals($expected, $schema);


### PR DESCRIPTION
Currently the annotations implementation does not support defining maps and arrays with complex types, this PR adds support to it.

In order to keep compatibility, the `@SerDe\AvroItems` and `@SerDe\AvroValues` annotations 
now may receive `string|AvroType|array<string|AvroType>`. The array syntax illustrates union types. Example usage:

```php
<?php

declare(strict_types=1);

namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture;

use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;

/**
 * @SerDe\AvroType("record")
 * @SerDe\AvroName("ExampleUsage")
 */
class ExampleUsage
{
    /**
     * @SerDe\AvroType("array", attributes={
     *     @SerDe\AvroItems({
     *         "string",
     *         @SerDe\AvroType("array", attributes={@SerDe\AvroItems(@SerDe\AvroType("string"))})
     *     })
     * })
     */
    private $arrayWithUnion;

    /**
     * @SerDe\AvroType("array", attributes={
     *     @SerDe\AvroItems(
     *         @SerDe\AvroType("map", attributes={@SerDe\AvroValues(@SerDe\AvroType("string"))})
     *     )
     * })
     */
    private $arrayWithMap;

    /**
     * @SerDe\AvroType("map", attributes={
     *     @SerDe\AvroValues({
     *         "string",
     *         @SerDe\AvroType("array", attributes={@SerDe\AvroItems("string")})
     *     })
     * })
     */
    private $mapWithUnion;

    /**
     * @SerDe\AvroType("map", attributes={
     *     @SerDe\AvroValues(
     *         @SerDe\AvroType("array", attributes={@SerDe\AvroItems("string")})
     *     )
     * })
     */
    private $mapWithArray;
}
```

Fixes #40