### PR TITLE
Improve symfony/serializer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,44 @@ Assert::assertEquals($deserializedUser, $user);
 
 ```
 
+### Name converter
+
+Sometimes your property names may differ from the names of the fields in your schema. One option
+to solve this is by using [custom Serializer annotations](https://symfony.com/doc/current/components/serializer.html#configure-name-conversion-using-metadata). However, if you're using the annotations
+provided by this library, 
+you may use our [name converter](integrations/Symfony/Serializer/NameConverter/AvroNameConverter.php)
+that parses these annotations and maps between the schema field names and the property names.
+
+```php
+<?php
+
+use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder;
+use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\NameConverter\AvroNameConverter;
+use FlixTech\AvroSerializer\Objects\DefaultRecordSerializerFactory;
+use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+use Symfony\Component\Serializer\Serializer;
+use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\AnnotationReader;
+
+$recordSerializer = DefaultRecordSerializerFactory::get(
+    getenv('SCHEMA_REGISTRY_HOST')
+);
+
+AnnotationRegistry::registerLoader('class_exists');
+
+$reader = new AnnotationReader(
+    new DoctrineAnnotationReader()
+);
+
+$nameConverter = new AvroNameConverter($reader);
+
+$normalizer = new GetSetMethodNormalizer(null, $nameConverter);
+$encoder = new AvroSerDeEncoder($recordSerializer);
+
+$symfonySerializer = new Serializer([$normalizer], [$encoder]);
+```
+
 ## Schema builder
 
 This library also provides means of defining schemas using php, very similar to 

--- a/integrations/Symfony/Serializer/NameConverter/AvroNameConverter.php
+++ b/integrations/Symfony/Serializer/NameConverter/AvroNameConverter.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Integrations\Symfony\Serializer\NameConverter;
+
+use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder;
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributeReader;
+use ReflectionClass;
+use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
+
+if (!interface_exists(\Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface::class)) {
+    throw new \Exception("The advanced name converter is supported only in symfony 4 and forward");
+}
+
+class AvroNameConverter implements AdvancedNameConverterInterface
+{
+    /**
+     * @var SchemaAttributeReader
+     */
+    private $attributeReader;
+
+    /**
+     * @var array<string, PropertyNameMap>
+     */
+    private $mapCache = [];
+
+    public function __construct(SchemaAttributeReader $attributeReader)
+    {
+        $this->attributeReader = $attributeReader;
+    }
+
+    public function normalize(
+        $propertyName,
+        string $class = null,
+        string $format = null,
+        array $context = []
+    ): string {
+        return $this
+            ->getNameMap($class, $format)
+            ->getNormalized($propertyName);
+    }
+
+    private function getNameMap(?string $class, ?string $format): PropertyNameMap
+    {
+        if (null === $class || !class_exists($class)) {
+            return new PropertyNameMap();
+        }
+
+        if (null === $format || AvroSerDeEncoder::FORMAT_AVRO !== $format) {
+            return new PropertyNameMap();
+        }
+
+        return $this->generateMap($class);
+    }
+
+    private function generateMap(string $class): PropertyNameMap
+    {
+        if (isset($this->mapCache[$class])) {
+            return $this->mapCache[$class];
+        }
+
+        $map = new PropertyNameMap();
+
+        $reflectionClass = new ReflectionClass($class);
+        foreach ($reflectionClass->getProperties() as $reflectionProperty) {
+            $schemaAttributes = $this->attributeReader->readPropertyAttributes($reflectionProperty);
+
+            if (!$schemaAttributes->has(AttributeName::NAME)) {
+                continue;
+            }
+
+            $attributeName = $schemaAttributes->get(AttributeName::NAME);
+
+            if (!is_string($attributeName)) {
+                continue;
+            }
+
+            $map = $map->add(
+                $reflectionProperty->getName(),
+                $attributeName
+            );
+        }
+
+        $this->mapCache[$class] = $map;
+
+        return $map;
+    }
+
+    public function denormalize(
+        $propertyName,
+        string $class = null,
+        string $format = null,
+        array $context = []
+    ): string {
+        return $this
+            ->getNameMap($class, $format)
+            ->getDenormalized($propertyName);
+    }
+}

--- a/integrations/Symfony/Serializer/NameConverter/PropertyNameMap.php
+++ b/integrations/Symfony/Serializer/NameConverter/PropertyNameMap.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Integrations\Symfony\Serializer\NameConverter;
+
+class PropertyNameMap
+{
+    private $propertyToSchemaMap = [];
+    private $schemaToPropertyMap = [];
+
+    public function add(string $propertyName, string $schemaName): self
+    {
+        $map = clone $this;
+
+        $map->propertyToSchemaMap[$propertyName] = $schemaName;
+        $map->schemaToPropertyMap[$schemaName] = $propertyName;
+
+        return $map;
+    }
+
+    public function getNormalized(string $name): string
+    {
+        return $this->propertyToSchemaMap[$name] ?? $name;
+    }
+
+    public function getDenormalized(string $name): string
+    {
+        return $this->schemaToPropertyMap[$name] ?? $name;
+    }
+}

--- a/src/Objects/Schema/Generation/AnnotationReader.php
+++ b/src/Objects/Schema/Generation/AnnotationReader.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
 
-use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
+use Doctrine\Common\Annotations\Reader as DoctrineAnnotationReader;
 use ReflectionClass;
 use ReflectionProperty;
 

--- a/src/Objects/Schema/Generation/Annotations/AvroAliases.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroAliases.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
 
 use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
 use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\VariadicAttribute;
 
 /**
  * @Annotation
  */
-final class AvroAliases implements SchemaAttribute
+final class AvroAliases implements VariadicAttribute
 {
     /**
      * @var array<string>

--- a/src/Objects/Schema/Generation/Annotations/AvroItems.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroItems.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
 
 use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\TypeOnlyAttribute;
 
 /**
  * @Annotation
  */
-final class AvroItems implements SchemaAttribute
+final class AvroItems implements TypeOnlyAttribute
 {
-    /**
-     * @var string
-     */
-    public $value;
+    use ContainsOnlyTypes;
 
     /**
      * {@inheritdoc}
@@ -24,21 +20,5 @@ final class AvroItems implements SchemaAttribute
     public function name(): string
     {
         return AttributeName::ITEMS;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function value(): string
-    {
-        return $this->value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function attributes(): SchemaAttributes
-    {
-        return new SchemaAttributes();
     }
 }

--- a/src/Objects/Schema/Generation/Annotations/AvroSymbols.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroSymbols.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
 
 use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
 use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\VariadicAttribute;
 
 /**
  * @Annotation
  */
-final class AvroSymbols implements SchemaAttribute
+final class AvroSymbols implements VariadicAttribute
 {
     /**
      * @var array<string>

--- a/src/Objects/Schema/Generation/Annotations/AvroType.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroType.php
@@ -23,6 +23,16 @@ final class AvroType implements SchemaAttribute
      */
     public $attributes = [];
 
+    public static function create(string $typeName, SchemaAttribute ...$attributes): self
+    {
+        $avroType = new self();
+
+        $avroType->value = $typeName;
+        $avroType->attributes = $attributes;
+
+        return $avroType;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Objects/Schema/Generation/Annotations/AvroValues.php
+++ b/src/Objects/Schema/Generation/Annotations/AvroValues.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
 
 use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
-use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\TypeOnlyAttribute;
 
 /**
  * @Annotation
  */
-final class AvroValues implements SchemaAttribute
+final class AvroValues implements TypeOnlyAttribute
 {
-    /**
-     * @var string
-     */
-    public $value;
+    use ContainsOnlyTypes;
 
     /**
      * {@inheritdoc}
@@ -24,21 +20,5 @@ final class AvroValues implements SchemaAttribute
     public function name(): string
     {
         return AttributeName::VALUES;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function value(): string
-    {
-        return $this->value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function attributes(): SchemaAttributes
-    {
-        return new SchemaAttributes();
     }
 }

--- a/src/Objects/Schema/Generation/Annotations/ContainsOnlyTypes.php
+++ b/src/Objects/Schema/Generation/Annotations/ContainsOnlyTypes.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttribute;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributes;
+
+trait ContainsOnlyTypes
+{
+    /**
+     * @phpstan-var string|AvroType|array<string|AvroType>
+     */
+    public $value;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return array<SchemaAttribute>
+     */
+    public function value(): array
+    {
+        if (!\is_array($this->value)) {
+            return [$this->valueToType($this->value)];
+        }
+
+        return \array_map([$this, 'valueToType'], $this->value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributes(): SchemaAttributes
+    {
+        return new SchemaAttributes(...$this->value());
+    }
+
+    /**
+     * @param string|AvroType $value
+     */
+    private function valueToType($value): AvroType
+    {
+        if ($value instanceof AvroType) {
+            return $value;
+        }
+
+        return AvroType::create($value);
+    }
+}

--- a/src/Objects/Schema/Generation/SchemaAttributes.php
+++ b/src/Objects/Schema/Generation/SchemaAttributes.php
@@ -26,11 +26,16 @@ class SchemaAttributes implements \Countable
     }
 
     /**
-     * @return array<SchemaAttribute>
+     * @return array<Type>
      */
     public function types(): array
     {
-        return $this->attributes[AttributeName::TYPE] ?? [];
+        return \array_map(function (SchemaAttribute $schemaAttribute) {
+            return new Type(
+                $schemaAttribute->value(),
+                $schemaAttribute->attributes()
+            );
+        }, $this->attributes[AttributeName::TYPE] ?? []);
     }
 
     /**

--- a/src/Objects/Schema/Generation/Type.php
+++ b/src/Objects/Schema/Generation/Type.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+class Type
+{
+    /**
+     * @var string
+     */
+    private $typeName;
+
+    /**
+     * @var SchemaAttributes
+     */
+    private $attributes;
+
+    public function __construct(string $typeName, SchemaAttributes $attributes = null)
+    {
+        $this->typeName = $typeName;
+        $this->attributes = $attributes ?? new SchemaAttributes();
+    }
+
+    public function getTypeName(): string
+    {
+        return $this->typeName;
+    }
+
+    public function getAttributes(): SchemaAttributes
+    {
+        return $this->attributes;
+    }
+}

--- a/src/Objects/Schema/Generation/TypeOnlyAttribute.php
+++ b/src/Objects/Schema/Generation/TypeOnlyAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+/**
+ * Marker interface to indicate that the attribute contains only type attributes
+ */
+interface TypeOnlyAttribute extends SchemaAttribute
+{
+}

--- a/src/Objects/Schema/Generation/VariadicAttribute.php
+++ b/src/Objects/Schema/Generation/VariadicAttribute.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+/**
+ * Marker interface to indicate that the attribute contains variadic values
+ */
+interface VariadicAttribute extends SchemaAttribute
+{
+    /**
+     * @return array<mixed>
+     */
+    public function value(): array;
+}

--- a/test/Integrations/Symfony/Serializer/AvroNameConverterTest.php
+++ b/test/Integrations/Symfony/Serializer/AvroNameConverterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Integrations\Symfony\Serializer;
+
+use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder;
+use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\NameConverter\AvroNameConverter;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\AnnotationReader;
+use FlixTech\AvroSerializer\Test\Integrations\Symfony\Serializer\Fixture\SampleUserRecord;
+use PHPUnit\Framework\TestCase;
+
+class AvroNameConverterTest extends TestCase
+{
+    /**
+     * @var AvroNameConverter
+     */
+    private $nameConverter;
+
+    protected function setUp()
+    {
+        if (!\interface_exists(\Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface::class)) {
+            $this->markTestSkipped('The advanced name converter is supported only in symfony 4 and forward');
+        }
+
+        $this->nameConverter = new AvroNameConverter(
+            new AnnotationReader(new \Doctrine\Common\Annotations\AnnotationReader())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_the_normalized_property_name(): void
+    {
+        $normalizedName = $this->nameConverter
+            ->normalize('name', SampleUserRecord::class, AvroSerDeEncoder::FORMAT_AVRO);
+        $this->assertEquals('Name', $normalizedName);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_the_denormalized_property_name(): void
+    {
+        $normalizedName = $this->nameConverter
+            ->denormalize('Name', SampleUserRecord::class, AvroSerDeEncoder::FORMAT_AVRO);
+        $this->assertEquals('name', $normalizedName);
+    }
+}

--- a/test/Integrations/Symfony/Serializer/Fixture/SampleUserRecord.php
+++ b/test/Integrations/Symfony/Serializer/Fixture/SampleUserRecord.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Integrations\Symfony\Serializer\Fixture;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroType("record")
+ * @SerDe\AvroName("SampleUserRecord")
+ */
+class SampleUserRecord
+{
+    /**
+     * @SerDe\AvroName("Name")
+     * @SerDe\AvroType("string")
+     */
+    private $name;
+}

--- a/test/Objects/Schema/Generation/Fixture/ArraysWithComplexType.php
+++ b/test/Objects/Schema/Generation/Fixture/ArraysWithComplexType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroType("record")
+ * @SerDe\AvroName("ArraysWithComplexType")
+ */
+class ArraysWithComplexType
+{
+    /**
+     * @SerDe\AvroType("array", attributes={
+     *     @SerDe\AvroItems({
+     *         "string",
+     *         @SerDe\AvroType("array", attributes={@SerDe\AvroItems(@SerDe\AvroType("string"))})
+     *     })
+     * })
+     */
+    private $arrayWithUnion;
+
+    /**
+     * @SerDe\AvroType("array", attributes={
+     *     @SerDe\AvroItems(
+     *         @SerDe\AvroType("map", attributes={@SerDe\AvroValues(@SerDe\AvroType("string"))})
+     *     )
+     * })
+     */
+    private $arrayWithMap;
+}

--- a/test/Objects/Schema/Generation/Fixture/MapsWithComplexType.php
+++ b/test/Objects/Schema/Generation/Fixture/MapsWithComplexType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroType("record")
+ * @SerDe\AvroName("MapsWithComplexType")
+ */
+class MapsWithComplexType
+{
+    /**
+     * @SerDe\AvroType("map", attributes={
+     *     @SerDe\AvroValues({
+     *         "string",
+     *         @SerDe\AvroType("array", attributes={@SerDe\AvroItems("string")})
+     *     })
+     * })
+     */
+    private $mapWithUnion;
+
+    /**
+     * @SerDe\AvroType("map", attributes={
+     *     @SerDe\AvroValues(
+     *         @SerDe\AvroType("array", attributes={@SerDe\AvroItems("string")})
+     *     )
+     * })
+     */
+    private $mapWithArray;
+}

--- a/test/Objects/Schema/Generation/SchemaGeneratorTest.php
+++ b/test/Objects/Schema/Generation/SchemaGeneratorTest.php
@@ -7,7 +7,9 @@ namespace FlixTech\AvroSerializer\Test\Objects\Schema\Generation;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use FlixTech\AvroSerializer\Objects\Schema;
+use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\ArraysWithComplexType;
 use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\EmptyRecord;
+use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\MapsWithComplexType;
 use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\PrimitiveTypes;
 use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\RecordWithComplexTypes;
 use FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\RecordWithRecordType;
@@ -154,6 +156,66 @@ class SchemaGeneratorTest extends TestCase
                     ->name('SimpleRecord')
                     ->namespace('org.acme')
                     ->field('intType', Schema::int(), Schema\Record\FieldOption::default(42))
+            );
+
+        $this->assertEquals($expected, $schema);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_a_record_schema_with_arrays_containing_complex_types()
+    {
+        $schema = $this->generator->generate(ArraysWithComplexType::class);
+
+        $expected = Schema::record()
+            ->name('ArraysWithComplexType')
+            ->field(
+                'arrayWithUnion',
+                Schema::array()
+                    ->items(
+                        Schema::union(
+                            Schema::string(),
+                            Schema::array()->items(Schema::string())
+                        )
+                    )
+            )
+            ->field(
+                'arrayWithMap',
+                Schema::array()
+                    ->items(
+                        Schema::map()->values(Schema::string())
+                    )
+            );
+
+        $this->assertEquals($expected, $schema);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_a_record_schema_with_maps_containing_complex_types()
+    {
+        $schema = $this->generator->generate(MapsWithComplexType::class);
+
+        $expected = Schema::record()
+            ->name('MapsWithComplexType')
+            ->field(
+                'mapWithUnion',
+                Schema::map()
+                    ->values(
+                        Schema::union(
+                            Schema::string(),
+                            Schema::array()->items(Schema::string())
+                        )
+                    )
+            )
+            ->field(
+                'mapWithArray',
+                Schema::map()
+                    ->values(
+                        Schema::array()->items(Schema::string())
+                    )
             );
 
         $this->assertEquals($expected, $schema);


### PR DESCRIPTION
When serializing or deserializing objects, the property names may differ from the schema defined names. One option to overcome this issue is by using custom serializer annotations in the class properties.

However, since we have the Schema Generation feature that allows us to generate schema definition from class metadata, it seems to make sense to use the very same information to convert the names between the class property and the ones defined in the avro schema.

So, in this PR I create a NameConverter class, to be used with the serializer component, that does just that.