### PR TITLE
Improve symfony/serializer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,44 @@ Assert::assertEquals($deserializedUser, $user);
 
 ```
 
+### Name converter
+
+Sometimes your property names may differ from the names of the fields in your schema. One option
+to solve this is by using [custom Serializer annotations](https://symfony.com/doc/current/components/serializer.html#configure-name-conversion-using-metadata). However, if you're using the annotations
+provided by this library, 
+you may use our [name converter](integrations/Symfony/Serializer/NameConverter/AvroNameConverter.php)
+that parses these annotations and maps between the schema field names and the property names.
+
+```php
+<?php
+
+use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder;
+use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\NameConverter\AvroNameConverter;
+use FlixTech\AvroSerializer\Objects\DefaultRecordSerializerFactory;
+use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+use Symfony\Component\Serializer\Serializer;
+use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\AnnotationReader;
+
+$recordSerializer = DefaultRecordSerializerFactory::get(
+    getenv('SCHEMA_REGISTRY_HOST')
+);
+
+AnnotationRegistry::registerLoader('class_exists');
+
+$reader = new AnnotationReader(
+    new DoctrineAnnotationReader()
+);
+
+$nameConverter = new AvroNameConverter($reader);
+
+$normalizer = new GetSetMethodNormalizer(null, $nameConverter);
+$encoder = new AvroSerDeEncoder($recordSerializer);
+
+$symfonySerializer = new Serializer([$normalizer], [$encoder]);
+```
+
 ## Schema builder
 
 This library also provides means of defining schemas using php, very similar to 

--- a/integrations/Symfony/Serializer/NameConverter/AvroNameConverter.php
+++ b/integrations/Symfony/Serializer/NameConverter/AvroNameConverter.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Integrations\Symfony\Serializer\NameConverter;
+
+use Exception;
+use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder;
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributeReader;
+use ReflectionClass;
+use ReflectionProperty;
+use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
+
+if (!\interface_exists(AdvancedNameConverterInterface::class)) {
+    throw new Exception("The advanced name converter is supported only in symfony 4 and forward");
+}
+
+class AvroNameConverter implements AdvancedNameConverterInterface
+{
+    /**
+     * @var SchemaAttributeReader
+     */
+    private $attributeReader;
+
+    /**
+     * @var array<string, PropertyNameMap>
+     */
+    private $mapCache = [];
+
+    public function __construct(SchemaAttributeReader $attributeReader)
+    {
+        $this->attributeReader = $attributeReader;
+    }
+
+    public function normalize(
+        $propertyName,
+        string $class = null,
+        string $format = null,
+        array $context = []
+    ): string {
+        return $this
+            ->getNameMap($class, $format)
+            ->getNormalized($propertyName);
+    }
+
+    private function getNameMap(?string $class, ?string $format): PropertyNameMap
+    {
+        if (null === $class || !class_exists($class)) {
+            return new PropertyNameMap();
+        }
+
+        if (null === $format || AvroSerDeEncoder::FORMAT_AVRO !== $format) {
+            return new PropertyNameMap();
+        }
+
+        return $this->generateMap($class);
+    }
+
+    private function generateMap(string $class): PropertyNameMap
+    {
+        if (isset($this->mapCache[$class])) {
+            return $this->mapCache[$class];
+        }
+
+        $reflectionClass = new ReflectionClass($class);
+
+        $map = array_reduce(
+            $reflectionClass->getProperties(),
+            [$this, 'propertyToSchemaName'],
+            new PropertyNameMap()
+        );
+
+        $this->mapCache[$class] = $map;
+
+        return $map;
+    }
+
+    private function propertyToSchemaName(
+        PropertyNameMap $map,
+        ReflectionProperty $reflectionProperty
+    ): PropertyNameMap {
+        $schemaAttributes = $this->attributeReader->readPropertyAttributes($reflectionProperty);
+
+        if (!$schemaAttributes->has(AttributeName::NAME)) {
+            return $map;
+        }
+
+        $attributeName = $schemaAttributes->get(AttributeName::NAME);
+
+        if (!is_string($attributeName)) {
+            return $map;
+        }
+
+        return $map->add(
+            $reflectionProperty->getName(),
+            $attributeName
+        );
+    }
+
+    public function denormalize(
+        $propertyName,
+        string $class = null,
+        string $format = null,
+        array $context = []
+    ): string {
+        return $this
+            ->getNameMap($class, $format)
+            ->getDenormalized($propertyName);
+    }
+}

--- a/integrations/Symfony/Serializer/NameConverter/PropertyNameMap.php
+++ b/integrations/Symfony/Serializer/NameConverter/PropertyNameMap.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Integrations\Symfony\Serializer\NameConverter;
+
+class PropertyNameMap
+{
+    private $propertyToSchemaMap = [];
+    private $schemaToPropertyMap = [];
+
+    public function add(string $propertyName, string $schemaName): self
+    {
+        $map = clone $this;
+
+        $map->propertyToSchemaMap[$propertyName] = $schemaName;
+        $map->schemaToPropertyMap[$schemaName] = $propertyName;
+
+        return $map;
+    }
+
+    public function getNormalized(string $name): string
+    {
+        return $this->propertyToSchemaMap[$name] ?? $name;
+    }
+
+    public function getDenormalized(string $name): string
+    {
+        return $this->schemaToPropertyMap[$name] ?? $name;
+    }
+}

--- a/test/Integrations/Symfony/Serializer/AvroNameConverterTest.php
+++ b/test/Integrations/Symfony/Serializer/AvroNameConverterTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Integrations\Symfony\Serializer;
+
+use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
+use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder;
+use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\NameConverter\AvroNameConverter;
+use FlixTech\AvroSerializer\Objects\Schema\Generation\AnnotationReader;
+use FlixTech\AvroSerializer\Test\Integrations\Symfony\Serializer\Fixture\SampleUserRecord;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
+
+class AvroNameConverterTest extends TestCase
+{
+    /**
+     * @var AvroNameConverter
+     */
+    private $nameConverter;
+
+    protected function setUp(): void
+    {
+        if (!\interface_exists(AdvancedNameConverterInterface::class)) {
+            $this->markTestSkipped('The advanced name converter is supported only in symfony 4 and forward');
+        }
+
+        $this->nameConverter = new AvroNameConverter(
+            new AnnotationReader(new DoctrineAnnotationReader())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_the_normalized_property_name(): void
+    {
+        $normalizedName = $this->nameConverter
+            ->normalize('name', SampleUserRecord::class, AvroSerDeEncoder::FORMAT_AVRO);
+        $this->assertEquals('Name', $normalizedName);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_the_denormalized_property_name(): void
+    {
+        $normalizedName = $this->nameConverter
+            ->denormalize('Name', SampleUserRecord::class, AvroSerDeEncoder::FORMAT_AVRO);
+        $this->assertEquals('name', $normalizedName);
+    }
+}

--- a/test/Integrations/Symfony/Serializer/Fixture/SampleUserRecord.php
+++ b/test/Integrations/Symfony/Serializer/Fixture/SampleUserRecord.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Test\Integrations\Symfony\Serializer\Fixture;
+
+use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
+
+/**
+ * @SerDe\AvroType("record")
+ * @SerDe\AvroName("SampleUserRecord")
+ */
+class SampleUserRecord
+{
+    /**
+     * @SerDe\AvroName("Name")
+     * @SerDe\AvroType("string")
+     */
+    private $name;
+}


### PR DESCRIPTION
When serializing or deserializing objects, the property names may differ from the schema defined names. One option to overcome this issue is by using custom serializer annotations in the class properties.

However, since we have the Schema Generation feature that allows us to generate schema definition from class metadata, it seems to make sense to use the very same information to convert the names between the class property and the ones defined in the avro schema.

So, in this PR I create a NameConverter class, to be used with the serializer component, that does just that.

I messed up my last PR (#43) commits so I've created this new one.