### PR TITLE
[FIX] Use `a` instead of `A` binary decoding in `Protocol.php`

### DIFF
--- a/src/Objects/Schema/Generation/AnnotationReader.php
+++ b/src/Objects/Schema/Generation/AnnotationReader.php
@@ -25,6 +25,7 @@ class AnnotationReader implements SchemaAttributeReader
      */
     public function readClassAttributes(ReflectionClass $class): SchemaAttributes
     {
+        /** @var SchemaAttribute[] $annotations */
         $annotations = $this->reader->getClassAnnotations($class);
         $attributes = \array_filter($annotations, [$this, 'onlySchemaAttributes']);
 
@@ -33,6 +34,7 @@ class AnnotationReader implements SchemaAttributeReader
 
     public function readPropertyAttributes(ReflectionProperty $property): SchemaAttributes
     {
+        /** @var SchemaAttribute[] $annotations */
         $annotations = $this->reader->getPropertyAnnotations($property);
         $attributes = \array_filter($annotations, [$this, 'onlySchemaAttributes']);
 

--- a/src/Protocol.php
+++ b/src/Protocol.php
@@ -30,7 +30,7 @@ const encode = '\FlixTech\AvroSerializer\Protocol\encode';
 function encode(int $protocolVersion, int $schemaId, string $avroEncodedBinaryString): Either
 {
     /** @var bool|string $packed */
-    $packed = @\pack('CNA*', $protocolVersion, $schemaId, $avroEncodedBinaryString);
+    $packed = @\pack('CNa*', $protocolVersion, $schemaId, $avroEncodedBinaryString);
 
     return false !== $packed
         ? Right::of($packed)
@@ -38,7 +38,7 @@ function encode(int $protocolVersion, int $schemaId, string $avroEncodedBinarySt
         : Left::of(
             new AvroEncodingException(
                 \sprintf(
-                    'Could not pack message with format "CNA*", protocol version "%d" and schema id "%d"',
+                    'Could not pack message with format "CNa*", protocol version "%d" and schema id "%d"',
                     $protocolVersion,
                     $schemaId
                 )


### PR DESCRIPTION
Fixes #31 