### PR TITLE
Allow referencing previously defined named types

### DIFF
--- a/src/Objects/Schema.php
+++ b/src/Objects/Schema.php
@@ -19,6 +19,7 @@ use FlixTech\AvroSerializer\Objects\Schema\LocalTimestampMicros;
 use FlixTech\AvroSerializer\Objects\Schema\LocalTimestampMillisType;
 use FlixTech\AvroSerializer\Objects\Schema\LongType;
 use FlixTech\AvroSerializer\Objects\Schema\MapType;
+use FlixTech\AvroSerializer\Objects\Schema\NamedType;
 use FlixTech\AvroSerializer\Objects\Schema\NullType;
 use FlixTech\AvroSerializer\Objects\Schema\RecordType;
 use FlixTech\AvroSerializer\Objects\Schema\StringType;
@@ -69,6 +70,11 @@ abstract class Schema implements Definition
     public static function string(): StringType
     {
         return new StringType();
+    }
+
+    public static function named(string $name): NamedType
+    {
+        return new NamedType($name);
     }
 
     public static function record(): RecordType

--- a/src/Objects/Schema/Generation/TypeMapper.php
+++ b/src/Objects/Schema/Generation/TypeMapper.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema\Generation;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
+use FlixTech\AvroSerializer\Objects\Schema\TypeName;
+
+final class TypeMapper
+{
+    /**
+     * @var array<string, callable>
+     */
+    private $mappers;
+
+    public function __construct(SchemaGenerator $generator)
+    {
+        $this->mappers = [
+            TypeName::RECORD => $this->recordType($generator),
+            TypeName::NULL => $this->simpleType(Schema::null()),
+            TypeName::BOOLEAN => $this->simpleType(Schema::boolean()),
+            TypeName::INT => $this->simpleType(Schema::int()),
+            TypeName::LONG => $this->simpleType(Schema::long()),
+            TypeName::FLOAT => $this->simpleType(Schema::float()),
+            TypeName::DOUBLE => $this->simpleType(Schema::double()),
+            TypeName::BYTES => $this->simpleType(Schema::bytes()),
+            TypeName::STRING => $this->simpleType(Schema::string()),
+            TypeName::ARRAY => $this->simpleType(Schema::array()),
+            TypeName::MAP => $this->simpleType(Schema::map()),
+            TypeName::ENUM => $this->simpleType(Schema::enum()),
+            TypeName::FIXED => $this->simpleType(Schema::fixed()),
+        ];
+    }
+
+    public function toSchema(Type $type): Schema
+    {
+        $mapper = $this->mappers[$type->getTypeName()] ?? $this->namedType();
+
+        return $mapper($type);
+    }
+
+    private function simpleType(Schema $schema): callable
+    {
+        return function () use ($schema): Schema {
+            return $schema;
+        };
+    }
+
+    private function recordType(SchemaGenerator $generator): callable
+    {
+        return function (Type $type) use ($generator): Schema {
+            $attributes = $type->getAttributes();
+
+            if ($attributes->has(AttributeName::TARGET_CLASS)) {
+                return $generator->generate($attributes->get(AttributeName::TARGET_CLASS));
+            }
+
+            return Schema::record();
+        };
+    }
+
+    private function namedType(): callable
+    {
+        return function (Type $type): Schema {
+            return Schema::named($type->getTypeName());
+        };
+    }
+}

--- a/src/Objects/Schema/NamedType.php
+++ b/src/Objects/Schema/NamedType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlixTech\AvroSerializer\Objects\Schema;
+
+use FlixTech\AvroSerializer\Objects\Schema;
+
+class NamedType extends Schema
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function serialize(): string
+    {
+        return $this->name;
+    }
+}

--- a/test/Objects/Schema/Generation/Fixture/RecordWithRecordType.php
+++ b/test/Objects/Schema/Generation/Fixture/RecordWithRecordType.php
@@ -13,10 +13,18 @@ use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;
 class RecordWithRecordType
 {
     /**
-     * @SerDe\AvroName("simple")
+     * @SerDe\AvroName("simpleField")
      * @SerDe\AvroType("record", attributes={
-     *     @SerDe\AvroTargetClass("\FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\SimpleRecord")
+     *     @SerDe\AvroTargetClass("\FlixTech\AvroSerializer\Test\Objects\Schema\Generation\Fixture\SimpleRecord"),
+     *     @SerDe\AvroDoc("This a simple record for testing purposes")
      * })
      */
     private $simpleRecord;
+
+    /**
+     * @SerDe\AvroName("unionField")
+     * @SerDe\AvroType("null")
+     * @SerDe\AvroType("org.acme.SimpleRecord")
+     */
+    private $unionRecord;
 }

--- a/test/Objects/Schema/Generation/SchemaGeneratorTest.php
+++ b/test/Objects/Schema/Generation/SchemaGeneratorTest.php
@@ -151,11 +151,23 @@ class SchemaGeneratorTest extends TestCase
         $expected = Schema::record()
             ->name('RecordWithRecordType')
             ->field(
-                'simple',
+                'simpleField',
                 Schema::record()
                     ->name('SimpleRecord')
                     ->namespace('org.acme')
-                    ->field('intType', Schema::int(), Schema\Record\FieldOption::default(42))
+                    ->doc('This a simple record for testing purposes')
+                    ->field(
+                        'intType',
+                        Schema::int(),
+                        Schema\Record\FieldOption::default(42)
+                    ),
+            )
+            ->field(
+                'unionField',
+                Schema::union(
+                    Schema::null(),
+                    Schema::named('org.acme.SimpleRecord')
+                )
             );
 
         $this->assertEquals($expected, $schema);


### PR DESCRIPTION
Once a named type is defined, in order to reuse that same type it is
needed to reference that type by the name (as in the primitive types).

Add support for NamedTypes in both the schema builder and the schema
generator, which is a way of referencing previously defined named types.

As an example, the following snippet wouldn't work, because the schema cannot be parsed:

```php
<?php

declare(strict_types=1);

namespace Acme\Types;

use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;

/**
 * @SerDe\AvroName("SomeDocument")
 * @SerDe\AvroType("record")
 */
class SomeDocument
{
    /**
     * @SerDe\AvroName("Status")
     * @SerDe\AvroType("enum", attributes={
     *     @SerDe\AvroSymbols({"Undefined", "NotAuthorized", "Canceled"}),
     *     @SerDe\AvroName("Status")
     * })
     */
    private $status;
}
```

```php
<?php

declare(strict_types=1);

namespace Acme\Types;

use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;

/**
 * @SerDe\AvroType("record")
 * @SerDe\AvroName("SomeDocumentCdc")
 * @SerDe\AvroNamespace("org.acme.types")
 */
class SomeDocumentCdc
{
    /**
     * @SerDe\AvroName("NewDocument")
     * @SerDe\AvroType("record", attributes={
     *     @SerDe\AvroTargetClass("\Acme\Types\SomeDocument")
     * })
     */
    private $newDocument;

    /**
     * @SerDe\AvroName("OldDocument")
     * @SerDe\AvroType("null")
     * @SerDe\AvroType("record", attributes={
     *     @SerDe\AvroTargetClass("\Acme\Types\Some\Document")
     * })
     */
    private $oldDocument;
}
```
With this PR we'll be able to do the following:

```php
<?php

declare(strict_types=1);

namespace Acme\Types;

use FlixTech\AvroSerializer\Objects\Schema\Generation\Annotations as SerDe;

/**
 * @SerDe\AvroType("record")
 * @SerDe\AvroName("SomeDocumentCdc")
 * @SerDe\AvroNamespace("org.acme.types")
 */
class SomeDocumentCdc
{
    /**
     * @SerDe\AvroName("NewDocument")
     * @SerDe\AvroType("record", attributes={
     *     @SerDe\AvroTargetClass("\Acme\Types\SomeDocument")
     * })
     */
    private $newDocument;

    /**
     * @SerDe\AvroName("OldDocument")
     * @SerDe\AvroType("null")
     * @SerDe\AvroType("SomeDocument")
     */
    private $oldDocument;
}
```
```
