### PR TITLE
Fix encode method with Symfony v6

### DIFF
--- a/integrations/Symfony/Serializer/AvroSerDeEncoder.php
+++ b/integrations/Symfony/Serializer/AvroSerDeEncoder.php
@@ -51,7 +51,7 @@ class AvroSerDeEncoder implements EncoderInterface, DecoderInterface
      * @throws \AvroSchemaParseException
      * @throws \FlixTech\SchemaRegistryApi\Exception\SchemaRegistryException
      */
-    public function encode($data, $format, array $context = [])
+    public function encode($data, $format, array $context = []): string
     {
         $this->validateEncodeContext($context);
 


### PR DESCRIPTION
```
Declaration of FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder::encode($data, $format, array $context = []) must be compatible with Symfony\Component\Serializer\Encoder\EncoderInterface::encode(mixed $data, string $format, array $context = []): string
```