### PR TITLE
Add guzzlehttp promises ^2.0.0 as alternate version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php": "^7.3|^8.0",
     "beberlei/assert": "^2.9.9|~3.0",
     "flix-tech/confluent-schema-registry-api": "^8.0",
-    "guzzlehttp/promises": "^1.4.0",
+    "guzzlehttp/promises": "^1.4.0 || ^2.0.0",
     "flix-tech/avro-php": "^5.0",
     "widmogrod/php-functional": "^6.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php": "^7.3|^8.0",
     "beberlei/assert": "^2.9.9|~3.0",
     "flix-tech/confluent-schema-registry-api": "^8.0",
-    "guzzlehttp/promises": "^1.4.0 || ^2.0.0",
+    "guzzlehttp/promises": "^1.4.0|^2.0.0",
     "flix-tech/avro-php": "^5.0",
     "widmogrod/php-functional": "^6.0"
   },


### PR DESCRIPTION
Don't see any reason why it should be strictly locked to v1, seems that v2.0x installs by default for aws sdk and other popular packages, adding avro-serde-php forces to downgrade back to 1.4x. 