### PR TITLE
added decode() return type to match symfony 7.1

### DIFF
--- a/integrations/Symfony/Serializer/AvroSerDeEncoder.php
+++ b/integrations/Symfony/Serializer/AvroSerDeEncoder.php
@@ -32,7 +32,7 @@ class AvroSerDeEncoder implements EncoderInterface, DecoderInterface
      *
      * @throws \FlixTech\SchemaRegistryApi\Exception\SchemaRegistryException
      */
-    public function decode($data, $format, array $context = [])
+    public function decode($data, $format, array $context = []): mixed
     {
         $readersSchema = $context[self::CONTEXT_DECODE_READERS_SCHEMA] ?? null;
         Assert::that($readersSchema)->nullOr()->isInstanceOf(\AvroSchema::class);


### PR DESCRIPTION
symfony 7.1 throws an error due interface type mismatch

```
Fatal error: Declaration of FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder::decode($data, $format, array $context = []) must be compatible with Symfony\Component\Serializer\Encoder\DecoderInterface::decode(string $data, string $format, array $context = []): mixed in /srv/app/vendor/flix-tech/avro-serde-php/integrations/Symfony/Serializer/AvroSerDeEncoder.php on line 35
Symfony\Component\ErrorHandler\Error\FatalError]8;;file:///srv/app/vendor/symfony/error-handler/Error/FatalError.php#L14\^]8;;\ {#9
  #message: "Compile Error: Declaration of FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder::decode($data, $format, array $context = []) must be compatible with Symfony\Component\Serializer\Encoder\DecoderInterface::decode(string $data, string $format, array $context = []): mixed"
  #code: 0
  #file: "]8;;file:///srv/app/vendor/flix-tech/avro-serde-php/integrations/Symfony/Serializer/AvroSerDeEncoder.php#L35\/srv/app/vendor/flix-tech/avro-serde-php/integrations/Symfony/Serializer/AvroSerDeEncoder.php]8;;\"
  #line: 35
  -error: array:4 [
    "type" => 64
    "message" => "Declaration of FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder::decode($data, $format, array $context = []) must be compatible with Symfony\Component\Serializer\Encoder\DecoderInterface::decode(string $data, string $format, array $context = []): mixed"
    "file" => "/srv/app/vendor/flix-tech/avro-serde-php/integrations/Symfony/Serializer/AvroSerDeEncoder.php"
    "line" => 35
  ]
}
```