### PR TITLE
PHP 8.4 support

### DIFF
--- a/integrations/Symfony/Serializer/AvroSerDeEncoder.php
+++ b/integrations/Symfony/Serializer/AvroSerDeEncoder.php
@@ -37,7 +37,7 @@ class AvroSerDeEncoder implements EncoderInterface, DecoderInterface
         return $this->recordSerializer->decodeMessage($data, $readersSchema);
     }
 
-    public function supportsDecoding($format): bool
+    public function supportsDecoding(string $format): bool
     {
         return self::FORMAT_AVRO === $format;
     }
@@ -48,7 +48,7 @@ class AvroSerDeEncoder implements EncoderInterface, DecoderInterface
      * @throws \AvroSchemaParseException
      * @throws \FlixTech\SchemaRegistryApi\Exception\SchemaRegistryException
      */
-    public function encode($data, $format, array $context = []): string
+    public function encode(mixed $data, string $format, array $context = []): string
     {
         $this->validateEncodeContext($context);
 
@@ -59,7 +59,7 @@ class AvroSerDeEncoder implements EncoderInterface, DecoderInterface
         );
     }
 
-    public function supportsEncoding($format): bool
+    public function supportsEncoding(string $format): bool
     {
         return self::FORMAT_AVRO === $format;
     }

--- a/integrations/Symfony/Serializer/NameConverter/AvroNameConverter.php
+++ b/integrations/Symfony/Serializer/NameConverter/AvroNameConverter.php
@@ -7,9 +7,10 @@ namespace FlixTech\AvroSerializer\Integrations\Symfony\Serializer\NameConverter;
 use FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder;
 use FlixTech\AvroSerializer\Objects\Schema\AttributeName;
 use FlixTech\AvroSerializer\Objects\Schema\Generation\SchemaAttributeReader;
-use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
+use ReflectionException;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
-class AvroNameConverter implements AdvancedNameConverterInterface
+class AvroNameConverter implements NameConverterInterface
 {
     private SchemaAttributeReader $attributeReader;
 
@@ -24,12 +25,12 @@ class AvroNameConverter implements AdvancedNameConverterInterface
     }
 
     /**
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function normalize(
         string $propertyName,
-        string $class = null,
-        string $format = null,
+        ?string $class = null,
+        ?string $format = null,
         array $context = []
     ): string {
         return $this
@@ -38,7 +39,7 @@ class AvroNameConverter implements AdvancedNameConverterInterface
     }
 
     /**
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     private function getNameMap(?string $class, ?string $format): PropertyNameMap
     {
@@ -54,7 +55,7 @@ class AvroNameConverter implements AdvancedNameConverterInterface
     }
 
     /**
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     private function generateMap(string $class): PropertyNameMap
     {
@@ -98,12 +99,12 @@ class AvroNameConverter implements AdvancedNameConverterInterface
     }
 
     /**
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function denormalize(
         string $propertyName,
-        string $class = null,
-        string $format = null,
+        ?string $class = null,
+        ?string $format = null,
         array $context = []
     ): string {
         return $this


### PR DESCRIPTION
Switched `AdvancedNameConverterInterface` to `NameConverterInterface` in `AvroNameConverter`.
Updated method signatures in `AvroSerDeEncoder` and `AvroNameConverter` to include nullable type hints for compliance with PHP 8.4 standards.